### PR TITLE
Ensure pod readiness

### DIFF
--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -208,6 +208,10 @@ func (o *InspectOptions) Run() error {
 		}
 
 		// save operator data for each clusteroperator namespace
+		if len(namespaces) == 0 {
+			log.Printf("unable to find any namespaces related to clusteroperator/%s. Skipping namespaced data collection...\n", info.Name)
+		}
+
 		for _, namespace := range namespaces {
 			if err := o.gatherNamespaceData(path.Join(o.baseDir, "namespaces", namespace), namespace); err != nil {
 				if kapierrs.IsNotFound(err) {
@@ -256,11 +260,6 @@ func obtainClusterOperatorNamespaces(obj runtime.Object) ([]string, error) {
 
 		namespaces = append(namespaces, related.Name)
 		log.Printf("    Found related namespace %q for ClusterOperator %q...\n", related.Name, structuredCO.Name)
-	}
-	if len(namespaces) == 0 {
-		log.Printf("    Falling back to <operator> namespace %q for ClusterOperator %q. Unable to find any related namespaces in object status...\n", structuredCO.Name, structuredCO.Name)
-		log.Printf("    Falling back to <operand> namespace %q for ClusterOperator %q. Unable to find any related namespaces in object status...\n", strings.TrimSuffix(structuredCO.Name, "-operator"), structuredCO.Name)
-		namespaces = []string{structuredCO.Name, strings.TrimSuffix(structuredCO.Name, "-operator")}
 	}
 
 	return namespaces, nil

--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -539,11 +539,9 @@ func (o *InspectOptions) gatherPodData(destDir, namespace string, pod *corev1.Po
 	errs := []error{}
 
 	// skip gathering container data if containers are no longer running
-	running, err := util.PodRunningReady(pod)
-	if err != nil {
+	if running, err := util.PodRunningReady(pod); err != nil {
 		return err
-	}
-	if !running {
+	} else if !running {
 		log.Printf("        Skipping container data collection for pod %q: Pod not running\n", pod.Name)
 		return nil
 	}

--- a/pkg/util/pod_readiness.go
+++ b/pkg/util/pod_readiness.go
@@ -9,6 +9,10 @@ import (
 // PodRunningReady checks whether pod p's phase is running and it has a ready
 // condition of status true.
 func PodRunningReady(p *v1.Pod) (bool, error) {
+	if !hasReadyCondition(p) {
+		return false, nil
+	}
+
 	// Check the phase is running.
 	if p.Status.Phase != v1.PodRunning {
 		return false, fmt.Errorf("want pod '%s' on '%s' to be '%v' but was '%v'",
@@ -20,6 +24,18 @@ func PodRunningReady(p *v1.Pod) (bool, error) {
 			p.ObjectMeta.Name, p.Spec.NodeName, v1.PodReady, v1.ConditionTrue, p.Status.Conditions)
 	}
 	return true, nil
+}
+
+func hasReadyCondition(pod *v1.Pod) bool {
+	conditionReady := true
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type != v1.PodReady {
+			continue
+		}
+		conditionReady = cond.Status == v1.ConditionTrue
+		break
+	}
+	return conditionReady
 }
 
 // IsPodReady returns true if a pod is ready; false otherwise.


### PR DESCRIPTION
cc @deads2k 

Removes the hardcoded namespace backup for clusteroperator resources.
Ensure pods have a Ready: true condition before proceeding to collect data