### PR TITLE
Add dev-helpers and 'events' parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-openshift-must-gather
+bin/*

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 all:
-	mkdir -p ./bin && go build -o openshift-must-gather cmd/must-gather.go
+	mkdir -p ./bin && \
+		go build -o bin/openshift-must-gather cmd/must-gather.go && \
+		go build -o bin/openshift-dev-helpers dev-helpers/cmd/dev-helpers.go

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ Note: it is possible to run this tool to collect all clusteroperator data by omi
 ```
 ./bin/openshift-must-gather inspect clusteroperators
 ```
+
+#### Developers Only
+
+**WARNING**: The following tool is provided with no guarantees and might (and will) be changed at any time. Please do not rely on anything below in your scripts or automatization.
+
+Beside the `oppenshift-must-gather` binary the `openshift-dev-helpers` binary is also provided. This binary combines various
+tools useful for the OpenShift developers teams. 
+
+To list all events recorded during a test run and stored in `events.json` file, you can run this command:
+```bash
+./bin/openshift-dev-helpers events https://storage.googleapis.com/origin-ci-test/pr-logs/.../artifacts/e2e-aws/events.json --component=openshift-apiserver-operator
+```

--- a/dev-helpers/cmd/dev-helpers.go
+++ b/dev-helpers/cmd/dev-helpers.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	mustgather "github.com/openshift/must-gather/pkg/cmd"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type DevHelpersOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+
+	genericclioptions.IOStreams
+}
+
+func NewDevHelpersOptions(streams genericclioptions.IOStreams) *DevHelpersOptions {
+	return &DevHelpersOptions{
+		configFlags: genericclioptions.NewConfigFlags(),
+		IOStreams:   streams,
+	}
+}
+
+func NewCmdDevHelpers(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewDevHelpersOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "openshift-dev-helpers",
+		Short:        "Set of helpers for OpenShift developer teams",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(mustgather.NewCmdEvents("openshift-dev-helpers", streams))
+	return cmd
+}
+
+func (o *DevHelpersOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *DevHelpersOptions) Validate() error {
+	return nil
+}
+
+func (o *DevHelpersOptions) Run() error {
+	return nil
+}
+
+func main() {
+	flags := pflag.NewFlagSet("dev-helpers", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	root := NewCmdDevHelpers(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/events.go
+++ b/pkg/cmd/events.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/openshift/must-gather/pkg/util"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+)
+
+var (
+	eventsExample = `
+	# Parse events for "openshift-apiserver-operator"
+	%[1]s events https://<ci-artifacts>/events.json --component=openshift-apiserver-operator
+
+	# Print all available components in events
+	%[1]s events https://<ci-artifacts>/events.json --list-components
+`
+)
+
+type EventsOptions struct {
+	fileWriter *util.MultiSourceFileWriter
+	builder    *resource.Builder
+	args       []string
+
+	eventFileURL string
+
+	componentName  string
+	listComponents bool
+
+	genericclioptions.IOStreams
+}
+
+func NewEventsOptions(streams genericclioptions.IOStreams) *EventsOptions {
+	return &EventsOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdEvents(parentName string, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewEventsOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "events <URL> [flags]",
+		Short:        "Collect debugging data for a given cluster operator",
+		Example:      fmt.Sprintf(inspectExample, parentName),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&o.componentName, "component", "", "Name of the component to filter events for (eg. 'openshift-apiserver-operator')")
+	cmd.Flags().BoolVar(&o.listComponents, "list-components", false, "List all available component names in events")
+
+	return cmd
+}
+
+func (o *EventsOptions) Complete(command *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		o.eventFileURL = args[0]
+	}
+	return nil
+}
+
+func (o *EventsOptions) Validate() error {
+	if o.listComponents && len(o.componentName) > 0 {
+		return fmt.Errorf("cannot use list-events with component specified")
+	}
+	if o.listComponents {
+		return nil
+	}
+	if len(o.eventFileURL) == 0 {
+		return fmt.Errorf("the event URL must be specified")
+	}
+	if len(o.componentName) == 0 {
+		return fmt.Errorf("the component name must be specified")
+	}
+	return nil
+}
+
+func (o *EventsOptions) Run() error {
+	eventFileBytes, err := util.GetEventBytesFromURL(o.eventFileURL)
+	if err != nil {
+		return err
+	}
+	if err := util.PrintEvents(o.Out, eventFileBytes, o.componentName, o.listComponents); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -1,0 +1,93 @@
+package util
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/xeonx/timeago"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func GetEventBytesFromURL(eventFileURL string) ([]byte, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	response, err := client.Get(eventFileURL)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+		}
+	}()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get %q, HTTP code: %d", eventFileURL, response.StatusCode)
+	}
+	return ioutil.ReadAll(response.Body)
+}
+
+// PrintEvents prints the given events JSON in human readable way.
+// If componentName is provided, only events related to that component are printed out (use '*' to print all events).
+// If printComponents is provided we only print the component names.
+func PrintEvents(writer io.Writer, eventBytes []byte, componentName string, printComponents bool) error {
+	eventList := v1.EventList{}
+	if err := json.Unmarshal(eventBytes, &eventList); err != nil {
+		log.Fatal(err.Error())
+	}
+
+	sort.Slice(eventList.Items, func(i, j int) bool {
+		return eventList.Items[i].FirstTimestamp.Before(&eventList.Items[j].FirstTimestamp)
+	})
+
+	englishFormat := timeago.English
+	englishFormat.PastSuffix = " "
+	w := tabwriter.NewWriter(writer, 50, 0, 0, ' ', tabwriter.DiscardEmptyColumns)
+
+	components := sets.NewString()
+
+	for _, item := range eventList.Items {
+		if !components.Has(item.Source.Component) {
+			components.Insert(item.Source.Component)
+		}
+		if printComponents {
+			continue
+		}
+		if item.Source.Component != componentName && componentName != `*` {
+			continue
+		}
+		humanTime := englishFormat.FormatReference(eventList.Items[0].FirstTimestamp.Time, item.FirstTimestamp.Time)
+		message := item.Message
+		if componentName == `*` {
+			component := item.Source.Component
+			if len(component) > 35 {
+				component = component[0:35] + "..."
+			}
+			humanTime = component + "\t" + humanTime
+		}
+		if _, err := fmt.Fprintf(w, "%s  %s\t%s\n", humanTime, item.Reason, message); err != nil {
+			return err
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+	}
+
+	if printComponents {
+		if _, err := fmt.Fprintln(writer, strings.Join(components.List(), ",")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/xeonx/timeago/LICENSE
+++ b/vendor/github.com/xeonx/timeago/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Simon HEGE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/xeonx/timeago/README.md
+++ b/vendor/github.com/xeonx/timeago/README.md
@@ -1,0 +1,31 @@
+# timeago - A time formatting package
+
+## Install
+
+	go get github.com/xeonx/timeago
+
+## Docs
+
+<http://godoc.org/github.com/xeonx/timeago>
+
+## Use
+
+	package main
+
+	import (
+		"time"
+		"github.com/xeonx/timeago"
+	)
+		
+	func main() {
+		t := time.Now().Add(42 * time.Second)
+		
+		s := timeago.English.Format(t)
+		//s will contains "less than a minute ago"
+		
+		//...
+	}
+	
+## Tests
+
+`go test` is used for testing.

--- a/vendor/github.com/xeonx/timeago/timeago.go
+++ b/vendor/github.com/xeonx/timeago/timeago.go
@@ -1,0 +1,285 @@
+// Copyright 2013 Simon HEGE. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+//timeago allows the formatting of time in terms of fuzzy timestamps.
+//For example:
+//	one minute ago
+//	3 years ago
+//	in 2 minutes
+package timeago
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	Day   time.Duration = time.Hour * 24
+	Month time.Duration = Day * 30
+	Year  time.Duration = Day * 365
+)
+
+type FormatPeriod struct {
+	D    time.Duration
+	One  string
+	Many string
+}
+
+//Config allows the customization of timeago.
+//You may configure string items (language, plurals, ...) and
+//maximum allowed duration value for fuzzy formatting.
+type Config struct {
+	PastPrefix   string
+	PastSuffix   string
+	FuturePrefix string
+	FutureSuffix string
+
+	Periods []FormatPeriod
+
+	Zero string
+	Max  time.Duration //Maximum duration for using the special formatting.
+	//DefaultLayout is used if delta is greater than the minimum of last period
+	//in Periods and Max. It is the desired representation of the date 2nd of
+	// January 2006.
+	DefaultLayout string
+}
+
+//Predefined english configuration
+var English = Config{
+	PastPrefix:   "",
+	PastSuffix:   " ago",
+	FuturePrefix: "in ",
+	FutureSuffix: "",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "about a second", "%d seconds"},
+		FormatPeriod{time.Minute, "about a minute", "%d minutes"},
+		FormatPeriod{time.Hour, "about an hour", "%d hours"},
+		FormatPeriod{Day, "one day", "%d days"},
+		FormatPeriod{Month, "one month", "%d months"},
+		FormatPeriod{Year, "one year", "%d years"},
+	},
+
+	Zero: "about a second",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "2006-01-02",
+}
+
+var Portuguese = Config{
+	PastPrefix:   "há ",
+	PastSuffix:   "",
+	FuturePrefix: "daqui a ",
+	FutureSuffix: "",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "um segundo", "%d segundos"},
+		FormatPeriod{time.Minute, "um minuto", "%d minutos"},
+		FormatPeriod{time.Hour, "uma hora", "%d horas"},
+		FormatPeriod{Day, "um dia", "%d dias"},
+		FormatPeriod{Month, "um mês", "%d meses"},
+		FormatPeriod{Year, "um ano", "%d anos"},
+	},
+
+	Zero: "menos de um segundo",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "02-01-2006",
+}
+
+var Chinese = Config{
+	PastPrefix:   "",
+	PastSuffix:   "前",
+	FuturePrefix: "于 ",
+	FutureSuffix: "",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "1 秒", "%d 秒"},
+		FormatPeriod{time.Minute, "1 分钟", "%d 分钟"},
+		FormatPeriod{time.Hour, "1 小时", "%d 小时"},
+		FormatPeriod{Day, "1 天", "%d 天"},
+		FormatPeriod{Month, "1 月", "%d 月"},
+		FormatPeriod{Year, "1 年", "%d 年"},
+	},
+
+	Zero: "1 秒",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "2006-01-02",
+}
+
+//Predefined french configuration
+var French = Config{
+	PastPrefix:   "il y a ",
+	PastSuffix:   "",
+	FuturePrefix: "dans ",
+	FutureSuffix: "",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "environ une seconde", "moins d'une minute"},
+		FormatPeriod{time.Minute, "environ une minute", "%d minutes"},
+		FormatPeriod{time.Hour, "environ une heure", "%d heures"},
+		FormatPeriod{Day, "un jour", "%d jours"},
+		FormatPeriod{Month, "un mois", "%d mois"},
+		FormatPeriod{Year, "un an", "%d ans"},
+	},
+
+	Zero: "environ une seconde",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "02/01/2006",
+}
+
+//Predefined german configuration
+var German = Config{
+	PastPrefix:   "vor ",
+	PastSuffix:   "",
+	FuturePrefix: "in ",
+	FutureSuffix: "",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "einer Sekunde", "%d Sekunden"},
+		FormatPeriod{time.Minute, "einer Minute", "%d Minuten"},
+		FormatPeriod{time.Hour, "einer Stunde", "%d Stunden"},
+		FormatPeriod{Day, "einem Tag", "%d Tagen"},
+		FormatPeriod{Month, "einem Monat", "%d Monaten"},
+		FormatPeriod{Year, "einem Jahr", "%d Jahren"},
+	},
+
+	Zero: "einer Sekunde",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "02.01.2006",
+}
+
+//Predefined turkish configuration
+var Turkish = Config{
+	PastPrefix:   "",
+	PastSuffix:   " önce",
+	FuturePrefix: "",
+	FutureSuffix: " içinde",
+
+	Periods: []FormatPeriod{
+		FormatPeriod{time.Second, "yaklaşık bir saniye", "%d saniye"},
+		FormatPeriod{time.Minute, "yaklaşık bir dakika", "%d dakika"},
+		FormatPeriod{time.Hour, "yaklaşık bir saat", "%d saat"},
+		FormatPeriod{Day, "bir gün", "%d gün"},
+		FormatPeriod{Month, "bir ay", "%d ay"},
+		FormatPeriod{Year, "bir yıl", "%d yıl"},
+	},
+
+	Zero: "yaklaşık bir saniye",
+
+	Max:           73 * time.Hour,
+	DefaultLayout: "02/01/2006",
+}
+
+//Format returns a textual representation of the time value formatted according to the layout
+//defined in the Config. The time is compared to time.Now() and is then formatted as a fuzzy
+//timestamp (eg. "4 days ago")
+func (cfg Config) Format(t time.Time) string {
+	return cfg.FormatReference(t, time.Now())
+}
+
+//FormatReference is the same as Format, but the reference has to be defined by the caller
+func (cfg Config) FormatReference(t time.Time, reference time.Time) string {
+
+	d := reference.Sub(t)
+
+	if (d >= 0 && d >= cfg.Max) || (d < 0 && -d >= cfg.Max) {
+		return t.Format(cfg.DefaultLayout)
+	}
+
+	return cfg.FormatRelativeDuration(d)
+}
+
+//FormatRelativeDuration is the same as Format, but for time.Duration.
+//Config.Max is not used in this function, as there is no other alternative.
+func (cfg Config) FormatRelativeDuration(d time.Duration) string {
+
+	isPast := d >= 0
+
+	if d < 0 {
+		d = -d
+	}
+
+	s, _ := cfg.getTimeText(d, true)
+
+	if isPast {
+		return strings.Join([]string{cfg.PastPrefix, s, cfg.PastSuffix}, "")
+	} else {
+		return strings.Join([]string{cfg.FuturePrefix, s, cfg.FutureSuffix}, "")
+	}
+}
+
+//Round the duration d in terms of step.
+func round(d time.Duration, step time.Duration, roundCloser bool) time.Duration {
+
+	if roundCloser {
+		return time.Duration(float64(d)/float64(step) + 0.5)
+	}
+
+	return time.Duration(float64(d) / float64(step))
+}
+
+//Count the number of parameters in a format string
+func nbParamInFormat(f string) int {
+	return strings.Count(f, "%") - 2*strings.Count(f, "%%")
+}
+
+//Convert a duration to a text, based on the current config
+func (cfg Config) getTimeText(d time.Duration, roundCloser bool) (string, time.Duration) {
+	if len(cfg.Periods) == 0 || d < cfg.Periods[0].D {
+		return cfg.Zero, 0
+	}
+
+	for i, p := range cfg.Periods {
+
+		next := p.D
+		if i+1 < len(cfg.Periods) {
+			next = cfg.Periods[i+1].D
+		}
+
+		if i+1 == len(cfg.Periods) || d < next {
+
+			r := round(d, p.D, roundCloser)
+
+			if next != p.D && r == round(next, p.D, roundCloser) {
+				continue
+			}
+
+			if r == 0 {
+				return "", d
+			}
+
+			layout := p.Many
+			if r == 1 {
+				layout = p.One
+			}
+
+			if nbParamInFormat(layout) == 0 {
+				return layout, d - r*p.D
+			}
+
+			return fmt.Sprintf(layout, r), d - r*p.D
+		}
+	}
+
+	return d.String(), 0
+}
+
+//NoMax creates an new config without a maximum
+func NoMax(cfg Config) Config {
+	return WithMax(cfg, 9223372036854775807, time.RFC3339)
+}
+
+//WithMax creates an new config with special formatting limited to durations less than max.
+//Values greater than max will be formatted by the standard time package using the defaultLayout.
+func WithMax(cfg Config, max time.Duration, defaultLayout string) Config {
+	n := cfg
+	n.Max = max
+	n.DefaultLayout = defaultLayout
+	return n
+}

--- a/vendor/github.com/xeonx/timeago/timeago_test.go
+++ b/vendor/github.com/xeonx/timeago/timeago_test.go
@@ -1,0 +1,137 @@
+// Copyright 2013 Simon HEGE. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package timeago
+
+import (
+	"testing"
+	"time"
+)
+
+// Base time for testing
+var tBase = time.Date(2013, 8, 30, 12, 0, 0, 0, time.UTC)
+
+// Test data for TestFormatReference
+var formatReferenceTests = []struct {
+	t        time.Time // input time
+	ref      time.Time // input reference
+	cfg      Config    // input cfguage
+	expected string    // expected result
+}{
+	// Lang
+	{tBase, tBase, NoMax(English), "about a second ago"},
+	{tBase, tBase, NoMax(French), "il y a environ une seconde"},
+	{tBase, tBase, NoMax(Chinese), "1 秒前"},
+	{tBase, tBase, NoMax(Portuguese), "há menos de um segundo"},
+	{tBase, tBase, NoMax(German), "vor einer Sekunde"},
+	{tBase, tBase, NoMax(Turkish), "yaklaşık bir saniye önce"},
+
+	// Thresholds
+	{tBase, tBase.Add(1*time.Second + 500000000).Add(-1), NoMax(English), "about a second ago"},
+	{tBase, tBase.Add(1*time.Second + 500000000), NoMax(English), "2 seconds ago"},
+	{tBase, tBase.Add(1 * time.Minute), NoMax(English), "about a minute ago"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second).Add(-1), NoMax(English), "about a minute ago"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second), NoMax(English), "2 minutes ago"},
+	{tBase, tBase.Add(59*time.Minute + 30*time.Second), NoMax(English), "about an hour ago"},
+	{tBase, tBase.Add(90 * time.Minute), NoMax(English), "2 hours ago"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute).Add(-1), NoMax(English), "23 hours ago"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute), NoMax(English), "one day ago"},
+	{tBase, tBase.Add(36 * time.Hour), NoMax(English), "2 days ago"},
+	{tBase, tBase.Add(30 * 24 * time.Hour), NoMax(English), "one month ago"},
+	{tBase, tBase.Add(Year).Add(-30 * Day), NoMax(English), "11 months ago"},
+	{tBase, tBase.Add(Year), NoMax(English), "one year ago"},
+	{tBase, tBase.Add(547 * Day), NoMax(English), "one year ago"},
+	{tBase, tBase.Add(548 * Day), NoMax(English), "2 years ago"},
+	{tBase, tBase.Add(10 * Year), NoMax(English), "10 years ago"},
+
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), NoMax(Portuguese), "há uma hora"},
+	{tBase, tBase.Add(45 * 24 * time.Hour).Add(-1), NoMax(Portuguese), "há um mês"},
+	{tBase, tBase.Add(36 * time.Hour).Add(-1), NoMax(Portuguese), "há um dia"},
+	{tBase, tBase.Add(1 * time.Minute).Add(-500000001), NoMax(Portuguese), "há 59 segundos"},
+	{tBase, tBase.Add(59*time.Minute + 30*time.Second).Add(-1), NoMax(Portuguese), "há 59 minutos"},
+	{tBase, tBase.Add(30 * 24 * time.Hour).Add(-12*time.Hour - 1), NoMax(Portuguese), "há 29 dias"},
+	{tBase, tBase.Add(45 * 24 * time.Hour), NoMax(Portuguese), "há 2 meses"},
+	{tBase, tBase.Add(10 * Year), NoMax(Portuguese), "há 10 anos"},
+
+	{tBase, tBase.Add(1*time.Second + 500000000).Add(-1), NoMax(German), "vor einer Sekunde"},
+	{tBase, tBase.Add(1*time.Second + 500000000), NoMax(German), "vor 2 Sekunden"},
+	{tBase, tBase.Add(1 * time.Minute), NoMax(German), "vor einer Minute"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second).Add(-1), NoMax(German), "vor einer Minute"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second), NoMax(German), "vor 2 Minuten"},
+	{tBase, tBase.Add(59*time.Minute + 30*time.Second), NoMax(German), "vor einer Stunde"},
+	{tBase, tBase.Add(90 * time.Minute), NoMax(German), "vor 2 Stunden"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute).Add(-1), NoMax(German), "vor 23 Stunden"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute), NoMax(German), "vor einem Tag"},
+	{tBase, tBase.Add(36 * time.Hour), NoMax(German), "vor 2 Tagen"},
+	{tBase, tBase.Add(30 * 24 * time.Hour), NoMax(German), "vor einem Monat"},
+	{tBase, tBase.Add(Year).Add(-30 * Day), NoMax(German), "vor 11 Monaten"},
+	{tBase, tBase.Add(Year), NoMax(German), "vor einem Jahr"},
+	{tBase, tBase.Add(547 * Day), NoMax(German), "vor einem Jahr"},
+	{tBase, tBase.Add(548 * Day), NoMax(German), "vor 2 Jahren"},
+	{tBase, tBase.Add(10 * Year), NoMax(German), "vor 10 Jahren"},
+
+	// Turkish Thresholds
+	{tBase, tBase.Add(1*time.Second + 500000000).Add(-1), NoMax(Turkish), "yaklaşık bir saniye önce"},
+	{tBase, tBase.Add(1*time.Second + 500000000), NoMax(Turkish), "2 saniye önce"},
+	{tBase, tBase.Add(1 * time.Minute), NoMax(Turkish), "yaklaşık bir dakika önce"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second).Add(-1), NoMax(Turkish), "yaklaşık bir dakika önce"},
+	{tBase, tBase.Add(1*time.Minute + 30*time.Second), NoMax(Turkish), "2 dakika önce"},
+	{tBase, tBase.Add(59*time.Minute + 30*time.Second), NoMax(Turkish), "yaklaşık bir saat önce"},
+	{tBase, tBase.Add(90 * time.Minute), NoMax(Turkish), "2 saat önce"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute).Add(-1), NoMax(Turkish), "23 saat önce"},
+	{tBase, tBase.Add(23*time.Hour + 30*time.Minute), NoMax(Turkish), "bir gün önce"},
+	{tBase, tBase.Add(36 * time.Hour), NoMax(Turkish), "2 gün önce"},
+	{tBase, tBase.Add(30 * 24 * time.Hour), NoMax(Turkish), "bir ay önce"},
+	{tBase, tBase.Add(Year).Add(-30 * Day), NoMax(Turkish), "11 ay önce"},
+	{tBase, tBase.Add(Year), NoMax(Turkish), "bir yıl önce"},
+	{tBase, tBase.Add(547 * Day), NoMax(Turkish), "bir yıl önce"},
+	{tBase, tBase.Add(548 * Day), NoMax(Turkish), "2 yıl önce"},
+	{tBase, tBase.Add(10 * Year), NoMax(Turkish), "10 yıl önce"},
+
+	// Max
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), NoMax(English), "about an hour ago"},
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), WithMax(English, 90*time.Minute, ""), "about an hour ago"},
+	{tBase, tBase.Add(90 * time.Minute), WithMax(English, 90*time.Minute, "2006-01-02"), "2013-08-30"},
+
+	{tBase, tBase.Add(90 * time.Minute), WithMax(Portuguese, 90*time.Minute, "01-02-2006"), "08-30-2013"},
+
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), NoMax(German), "vor einer Stunde"},
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), WithMax(German, 90*time.Minute, ""), "vor einer Stunde"},
+	{tBase, tBase.Add(90 * time.Minute), WithMax(German, 90*time.Minute, German.DefaultLayout), "30.08.2013"},
+
+	// Turkish Max
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), NoMax(Turkish), "yaklaşık bir saat önce"},
+	{tBase, tBase.Add(90 * time.Minute).Add(-1), WithMax(Turkish, 90*time.Minute, ""), "yaklaşık bir saat önce"},
+	{tBase, tBase.Add(90 * time.Minute), WithMax(Turkish, 90*time.Minute, "02/01/2006"), "30/08/2013"},
+
+	// Future
+	{tBase.Add(24 * time.Hour), tBase, NoMax(English), "in one day"},
+	{tBase.Add(24 * time.Hour), tBase, NoMax(Turkish), "bir gün içinde"},
+
+	{tBase.Add(2 * Month), tBase, NoMax(Turkish), "2 ay içinde"},
+	{tBase.Add(5 * time.Minute), tBase, NoMax(Turkish), "5 dakika içinde"},
+	{tBase.Add(100 * time.Millisecond), tBase, NoMax(Turkish), "yaklaşık bir saniye içinde"},
+
+	{tBase.Add(2 * Month), tBase, NoMax(Portuguese), "daqui a 2 meses"},
+	{tBase.Add(24 * time.Hour), tBase, NoMax(Portuguese), "daqui a um dia"},
+	{tBase.Add(5 * time.Minute), tBase, NoMax(Portuguese), "daqui a 5 minutos"},
+	{tBase.Add(1 * time.Minute), tBase, NoMax(Portuguese), "daqui a um minuto"},
+	{tBase.Add(100 * time.Millisecond), tBase, NoMax(Portuguese), "daqui a menos de um segundo"},
+
+	{tBase.Add(2 * Month), tBase, NoMax(German), "in 2 Monaten"},
+	{tBase.Add(24 * time.Hour), tBase, NoMax(German), "in einem Tag"},
+	{tBase.Add(5 * time.Minute), tBase, NoMax(German), "in 5 Minuten"},
+	{tBase.Add(1 * time.Minute), tBase, NoMax(German), "in einer Minute"},
+	{tBase.Add(100 * time.Millisecond), tBase, NoMax(German), "in einer Sekunde"},
+}
+
+// Test the FormatReference method
+func TestFormatReference(t *testing.T) {
+	for i, tt := range formatReferenceTests {
+		actual := tt.cfg.FormatReference(tt.t, tt.ref)
+		if actual != tt.expected {
+			t.Errorf("%d) FormatReference(%s,%s): expected '%s', actual '%s'", i+1, tt.t, tt.ref, tt.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This will add second binary `./bin/openshift-dev-helpers` which will provide tools useful for OpenShift developer teams.

The first addition there is `events` command which will fetch the `events.json` file available in test artifacts and print its content in parsed, human-friendly form.

An example output of running:
`
$ ./bin/openshift-dev-helpers events https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/115/pull-ci-openshift-cluster-openshift-apiserver-operator-master-e2e-aws/510/artifacts/e2e-aws/events.json --component=openshift-cluster-kube-apiserver-operator
`

```bash
2 minutes   RoleCreated                           Created Rolerbac.authorization.k8s.io./prometheus-k8s -n openshift-kube-apiserver because it was missing
2 minutes   RoleBindingCreated                    Created RoleBindingrbac.authorization.k8s.io./prometheus-k8s -n openshift-kube-apiserver because it was missing
2 minutes   OperatorStatusChanged                 Status for operator openshift-kube-apiserver-operator changed: Failing changed from False to True ("ConfigObservationFailing: error writing updated observed config: Operation cannot be fulfilled on kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io \"instance\": the object has been modified; please apply your changes to the latest version and try again")
2 minutes   MasterNodeObserved                    Observed new master node ip-10-0-34-91.ec2.internal
2 minutes   LeaderElection                        3242a767-1a91-11e9-aadf-0a580a820006 became leader
2 minutes   MasterNodeObserved                    Observed new master node ip-10-0-0-59.ec2.internal
2 minutes   ObserveStorageUpdated                 Updated storage urls to https://ci-op-ym83zqs7-79e77-etcd-0.origin-ci-int-aws.dev.rhcloud.com:2379,https://ci-op-ym83zqs7-79e77-etcd-1.origin-ci-int-aws.dev.rhcloud.com:2379,https://ci-op-ym83zqs7-79e77-etcd-2.origin-ci-int-aws.dev.rhcloud.com:2379
2 minutes   OperatorStatusChanged                 Status for operator openshift-kube-apiserver-operator changed: Available set to False ("0 of 0 nodes are at revision 0"),Progressing set to False ("0 of 0 nodes are at revision 0"),status.relatedObjects changed from [] to [{"kubeapiserver.operator.openshift.io" "kubeapiserveroperatorconfigs" "" "instance"} {"" "namespaces" "" "openshift-config"} {"" "namespaces" "" "openshift-config-managed"} {"" "namespaces" "" "openshift-kube-apiserver-operator"} {"" "namespaces" "" "openshift-kube-apiserver"}]
2 minutes   OperatorStatusChanged                 Status for operator openshift-kube-apiserver-operator changed: Failing set to False (""),status.relatedObjects changed from [] to [{"kubeapiserver.operator.openshift.io" "kubeapiserveroperatorconfigs" "" "instance"} {"" "namespaces" "" "openshift-config"} {"" "namespaces" "" "openshift-config-managed"} {"" "namespaces" "" "openshift-kube-apiserver-operator"} {"" "namespaces" "" "openshift-kube-apiserver"}]
2 minutes   ServiceMonitorCreateFailed            Failed to create ServiceMonitor.monitoring.coreos.com/v1: the server could not find the requested resource
2 minutes   MasterNodeObserved                    Observed new master node ip-10-0-29-249.ec2.internal
2 minutes   ObservedConfigWriteError              Failed to write observed config: Operation cannot be fulfilled on kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io "instance": the object has been modified; please apply your changes to the latest version and try again
2 minutes   ObservedConfigChanged                 Writing updated observed config
2 minutes   SignerUpdateRequired                  "managed-kube-apiserver-serving-cert-signer" in "openshift-kube-apiserver-operator" requires a new signing cert/key pair
2 minutes   SignerUpdateRequired                  "managed-kube-apiserver-client-signer" in "openshift-kube-apiserver-operator" requires a new signing cert/key pair
2 minutes   SignerUpdateRequired                  "aggregator-client-signer" in "openshift-kube-apiserver-operator" requires a new signing cert/key pair
4 minutes   LeaderElection                        668e08f0-1a91-11e9-be88-0a580a820006 became leader
4 minutes   ServiceMonitorCreateFailed            Failed to create ServiceMonitor.monitoring.coreos.com/v1: the server could not find the requested resource
4 minutes   OperatorStatusChanged                 Status for operator openshift-kube-apiserver-operator changed: Available changed from False to True ("1 of 3 nodes are at revision 2"),Progressing message changed from "0 of 3 nodes are at revision 2, 3 are not" to "1 of 3 nodes are at revision 2, 2 are not"
4 minutes   NodeCurrentRevisionChanged            Updated node "ip-10-0-29-249.ec2.internal" from revision 0 to 2
4 minutes   NodeTargetRevisionChanged             Updating node "ip-10-0-34-91.ec2.internal" from revision 0 to 2
4 minutes   PodCreated                            Created Pod/installer-2-ip-10-0-34-91.ec2.internal -n openshift-kube-apiserver because it was missing
4 minutes   OperatorStatusChanged                 Status for operator openshift-kube-apiserver-operator changed: Available message changed from "1 of 3 nodes are at revision 2" to "2 of 3 nodes are at revision 2",Progressing message changed from "1 of 3 nodes are at revision 2, 2 are not" to "2 of 3 nodes are at revision 2, 1 are not"
4 minutes   NodeCurrentRevisionChanged            Updated node "ip-10-0-34-91.ec2.internal" from revision 0 to 2
5 minutes   NodeTargetRevisionChanged             Updating node "ip-10-0-0-59.ec2.internal" from revision 1 to 2
5 minutes   PodCreated                            Created Pod/installer-2-ip-10-0-0-59.ec2.internal -n openshift-kube-apiserver because it was missing
9 minutes   NodeCurrentRevisionChanged            Updated node "ip-10-0-0-59.ec2.internal" from revision 3 to 4
```

You can list all components in events.json via `--list-components` or use `*` as component name to see all events. If we need more robust filtering we can add it as follow up?