### PR TITLE
Gssdefaultsflag

### DIFF
--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -57,6 +58,8 @@ type InspectOptions struct {
 	baseDir string
 	// whether or not to allow writes to an existing and populated base directory
 	overwrite bool
+	// flag to indicate GSS defaults should be used in deciding what to gather
+	gssdefaults bool
 
 	genericclioptions.IOStreams
 }
@@ -66,6 +69,7 @@ func NewInspectOptions(streams genericclioptions.IOStreams) *InspectOptions {
 		printFlags:  genericclioptions.NewPrintFlags("gathered").WithDefaultOutput("yaml").WithTypeSetter(scheme.Scheme),
 		configFlags: genericclioptions.NewConfigFlags(),
 		overwrite:   true,
+		gssdefaults: false,
 		IOStreams:   streams,
 	}
 }
@@ -94,6 +98,7 @@ func NewCmdInspect(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&o.baseDir, "base-dir", "must-gather", "Root directory used for storing all gathered cluster operator data. Defaults to $(PWD)/must-gather")
+	cmd.Flags().BoolVar(&o.gssdefaults, "default", false, "If true, use Red Hat Support suggested default options for data filtering.  This can save space.")
 
 	o.printFlags.AddFlags(cmd)
 	return cmd
@@ -164,6 +169,8 @@ func (o *InspectOptions) Run() error {
 	if err := o.ensureDirectoryViable(o.baseDir, o.overwrite); err != nil {
 		return err
 	}
+
+	fmt.Println("GSSDefaults:" + strconv.FormatBool(o.gssdefaults))
 
 	// first, gather config.openshift.io resource data
 	errs := []error{}

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -169,8 +168,6 @@ func (o *InspectOptions) Run() error {
 	if err := o.ensureDirectoryViable(o.baseDir, o.overwrite); err != nil {
 		return err
 	}
-
-	fmt.Println("GSSDefaults:" + strconv.FormatBool(o.gssdefaults))
 
 	// first, gather config.openshift.io resource data
 	errs := []error{}


### PR DESCRIPTION
Add flag to indicate Red Hat Support suggested defaults to help filter the amount of data gathered.