### PR TITLE
add local file support for events

### DIFF
--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -18,6 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+func GetEventBytesFromLocalFile(eventFileName string) ([]byte, error) {
+	return ioutil.ReadFile(eventFileName)
+}
+
 func GetEventBytesFromURL(eventFileURL string) ([]byte, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
This allow to specify `-f` for events helper as google storage for test grid tests require auth and the URLs have ttl.