### PR TITLE
helper for inspecting cert resources

### DIFF
--- a/cmd/openshift-dev-helpers/main.go
+++ b/cmd/openshift-dev-helpers/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"github.com/openshift/must-gather/pkg/cmd/certinspection"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -47,6 +49,8 @@ func NewCmdDevHelpers(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.AddCommand(mustgather.NewCmdEvents("openshift-dev-helpers", streams))
 	cmd.AddCommand(mustgather.NewCmdAudit("openshift-dev-helpers", streams))
+	cmd.AddCommand(certinspection.NewCmdCertInspection(streams))
+
 	return cmd
 }
 

--- a/pkg/cmd/certinspection/certinspection.go
+++ b/pkg/cmd/certinspection/certinspection.go
@@ -1,0 +1,212 @@
+package certinspection
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/cert"
+)
+
+var (
+	example = `
+	# look at certs on the cluster in the "openshift-kube-apiserver" namespace
+	openshift-dev-helpers inspect-certs -n openshift-kube-apiserver secrets,configmaps
+
+	# look at certs from CSRs
+	openshift-dev-helpers inspect-certs csr
+
+	# create a fake secret from a file to inspect its content 
+	oc create secret generic --dry-run -oyaml kubelet --from-file=tls.crt=/home/deads/Downloads/kubelet-client-current.pem | openshift-dev-helpers inspect-certs --local -f -
+
+	# look at a dumped file of resources for inspection
+	openshift-dev-helpers inspect-certs --local -f 'path/to/core/configmaps.yaml'
+`
+)
+
+type CertInspectionOptions struct {
+	builderFlags *genericclioptions.ResourceBuilderFlags
+	configFlags  *genericclioptions.ConfigFlags
+
+	resourceFinder genericclioptions.ResourceFinder
+
+	genericclioptions.IOStreams
+}
+
+func NewCertInspectionOptions(streams genericclioptions.IOStreams) *CertInspectionOptions {
+	return &CertInspectionOptions{
+		builderFlags: genericclioptions.NewResourceBuilderFlags().
+			WithAll(true).
+			WithAllNamespaces(false).
+			WithFieldSelector("").
+			WithLabelSelector("").
+			WithLocal(false).
+			WithScheme(scheme.Scheme),
+		configFlags: genericclioptions.NewConfigFlags(),
+		IOStreams:   streams,
+	}
+}
+
+func NewCmdCertInspection(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCertInspectionOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "inspect-certs <resource>",
+		Short:        "Inspects the certs, keys, and ca-bundles in a set of resources.",
+		Example:      example,
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	o.builderFlags.AddFlags(cmd.Flags())
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *CertInspectionOptions) Complete(command *cobra.Command, args []string) error {
+	o.resourceFinder = o.builderFlags.ToBuilder(o.configFlags, args)
+
+	return nil
+}
+
+func (o *CertInspectionOptions) Validate() error {
+	return nil
+}
+
+func (o *CertInspectionOptions) Run() error {
+	visitor := o.resourceFinder.Do()
+
+	err := visitor.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+
+		switch castObj := info.Object.(type) {
+		case *corev1.ConfigMap:
+			inspectConfigMap(castObj)
+		case *corev1.Secret:
+			inspectSecret(castObj)
+		case *certificatesv1beta1.CertificateSigningRequest:
+			inspectCSR(castObj)
+		default:
+			return fmt.Errorf("unhandled resource: %T", castObj)
+		}
+
+		fmt.Println()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func inspectConfigMap(obj *corev1.ConfigMap) {
+	resourceString := fmt.Sprintf("configmaps/%s[%s]", obj.Name, obj.Namespace)
+	caBundle, ok := obj.Data["ca-bundle.crt"]
+	if !ok {
+		fmt.Printf("%s NOT a ca-bundle\n", resourceString)
+		return
+	}
+	if len(caBundle) == 0 {
+		fmt.Printf("%s MISSING ca-bundle content\n", resourceString)
+		return
+	}
+
+	fmt.Printf("%s - ca-bundle (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+	certificates, err := cert.ParseCertsPEM([]byte(caBundle))
+	if err != nil {
+		fmt.Printf("    ERROR - %v\n", err)
+		return
+	}
+	for _, curr := range certificates {
+		fmt.Printf("    %s\n", certDetail(curr))
+	}
+}
+
+func inspectSecret(obj *corev1.Secret) {
+	resourceString := fmt.Sprintf("secrets/%s[%s]", obj.Name, obj.Namespace)
+	tlsCrt, ok := obj.Data["tls.crt"]
+	if !ok {
+		fmt.Printf("%s NOT a tls secret\n", resourceString)
+		return
+	}
+	if len(tlsCrt) == 0 {
+		fmt.Printf("%s MISSING tls.crt content\n", resourceString)
+		return
+	}
+
+	fmt.Printf("%s - tls (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+	certificates, err := cert.ParseCertsPEM([]byte(tlsCrt))
+	if err != nil {
+		fmt.Printf("    ERROR - %v\n", err)
+		return
+	}
+	for _, curr := range certificates {
+		fmt.Printf("    %s\n", certDetail(curr))
+	}
+}
+
+func inspectCSR(obj *certificatesv1beta1.CertificateSigningRequest) {
+	resourceString := fmt.Sprintf("csr/%s", obj.Name)
+	if len(obj.Status.Certificate) == 0 {
+		fmt.Printf("%s NOT SIGNED\n", resourceString)
+		return
+	}
+
+	fmt.Printf("%s - (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+	certificates, err := cert.ParseCertsPEM([]byte(obj.Status.Certificate))
+	if err != nil {
+		fmt.Printf("    ERROR - %v\n", err)
+		return
+	}
+	for _, curr := range certificates {
+		fmt.Printf("    %s\n", certDetail(curr))
+	}
+}
+
+func certDetail(certificate *x509.Certificate) string {
+	humanName := certificate.Subject.CommonName
+	signerHumanName := certificate.Issuer.CommonName
+	if certificate.Subject.CommonName == certificate.Issuer.CommonName {
+		signerHumanName = "<self>"
+	}
+
+	usages := []string{}
+	for _, curr := range certificate.ExtKeyUsage {
+		if curr == x509.ExtKeyUsageClientAuth {
+			usages = append(usages, "client")
+		}
+		if curr == x509.ExtKeyUsageServerAuth {
+			usages = append(usages, "serving")
+		}
+		if curr == x509.ExtKeyUsageCodeSigning {
+			usages = append(usages, "signing")
+		}
+
+		usages = append(usages, fmt.Sprintf("%d", curr))
+	}
+
+	return fmt.Sprintf("%q [%s] issuer=%q (%v to %v)", humanName, strings.Join(usages, ","), signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC())
+}


### PR DESCRIPTION
I'm losing my mind debugging certs, so this allows `./openshift-dev-helpers inspect-certs --local -f '/home/deads/Downloads/decarr-01/openshift-kube-apiserver-configmaps'` or `./openshift-dev-helpers inspect-certs configmaps secrets` or `oc create secret generic --dry-run -oyaml kubelet --from-file=tls.crt=/home/deads/Downloads/kubelet-client-current.pem | ./openshift-dev-helpers inspect-certs --local -f -` to get output like:

```
$ ./openshift-dev-helpers inspect-certs --local -f '/home/deads/Downloads/decarr-01/openshift-kube-apiserver-configmaps'
    "kube-ca" issuer="root-ca" (2019-02-06 14:47:20 +0000 UTC to 2029-02-03 14:47:20 +0000 UTC)
    "kube-csr-signer_@1549465488" issuer="kube-csr-signer_@1549465488" (2019-02-06 15:04:48 +0000 UTC to 2019-02-06 19:04:49 +0000 UTC)
    "openshift-kube-controller-manager-operator_csr-signer-signer@1549465484" issuer="openshift-kube-controller-manager-operator_csr-signer-signer@1549465484" (2019-02-06 15:04:43 +0000 UTC to 2019-02-06 23:04:44 +0000 UTC)
```

```
$ oc create secret generic --dry-run -oyaml kubelet --from-file=tls.crt=/home/deads/Downloads/kubelet-client-current.pem | ./openshift-dev-helpers inspect-certs --local -f -
secrets/kubelet[] - tls
    "system:node:ip-10-0-138-69.us-east-2.compute.internal" issuer="kube-csr-signer_@1549465488" (2019-02-06 15:05:00 +0000 UTC to 2019-02-06 18:59:31 +0000 UTC)
```

@sttts we can go humanreadable some other time. This is the minimum bar for me
@mfojtik 