### PR TITLE
fix the namespace resource layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 openshift-dev-helpers
 openshift-must-gather
+
+must-gather

--- a/pkg/cmd/inspect/namespace.go
+++ b/pkg/cmd/inspect/namespace.go
@@ -1,0 +1,83 @@
+package inspect
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+)
+
+// TODO someone may later choose to use discovery information to determine what to collect
+func namespaceResourcesToCollect() []schema.GroupResource {
+	return []schema.GroupResource{
+		// this is actually a group which collects most useful things
+		{Resource: "all"},
+		{Resource: "events"},
+		{Resource: "configmaps"},
+		{Resource: "secrets"},
+	}
+}
+
+func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
+	log.Printf("Gathering data for ns/%s...\n", namespace)
+
+	destDir := path.Join(baseDir, namespaceResourcesDirname, namespace)
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	ns, err := o.kubeClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil { // If we can't get the namespace we need to exit out
+		return err
+	}
+	ns.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+
+	errs := []error{}
+	// write namespace.yaml file
+	filename := fmt.Sprintf("%s.yaml", namespace)
+	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), ns); err != nil {
+		errs = append(errs, err)
+	}
+
+	log.Printf("    Collecting resources for namespace %q...\n", namespace)
+
+	resourcesTypesToStore := map[schema.GroupVersionResource]bool{
+		corev1.SchemeGroupVersion.WithResource("pods"): true,
+	}
+	resourcesToStore := map[schema.GroupVersionResource]runtime.Object{}
+
+	// collect specific resource information for namespace
+	for gvr := range resourcesTypesToStore {
+		list, err := o.dynamicClient.Resource(gvr).Namespace(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+		}
+		resourcesToStore[gvr] = list
+	}
+
+	log.Printf("    Gathering pod data for namespace %q...\n", namespace)
+	// gather specific pod data
+	for _, pod := range resourcesToStore[corev1.SchemeGroupVersion.WithResource("pods")].(*unstructured.UnstructuredList).Items {
+		log.Printf("        Gathering data for pod %q\n", pod.GetName())
+		structuredPod := &corev1.Pod{}
+		runtime.DefaultUnstructuredConverter.FromUnstructured(pod.Object, structuredPod)
+		if err := o.gatherPodData(path.Join(destDir, "/pods/"+pod.GetName()), namespace, structuredPod); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
+	}
+	return nil
+}

--- a/pkg/cmd/inspect/pod.go
+++ b/pkg/cmd/inspect/pod.go
@@ -1,0 +1,285 @@
+package inspect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/openshift/must-gather/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/rest"
+)
+
+func (o *InspectOptions) gatherPodData(destDir, namespace string, pod *corev1.Pod) error {
+	if pod.Status.Phase != corev1.PodRunning {
+		log.Printf("        Skipping container data collection for pod %q: Pod not running\n", pod.Name)
+		return nil
+	}
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s.yaml", pod.Name)
+	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), pod); err != nil {
+		return err
+	}
+
+	errs := []error{}
+
+	// skip gathering container data if containers are no longer running
+	if running, err := util.PodRunningReady(pod); err != nil {
+		return err
+	} else if !running {
+		log.Printf("        Skipping container data collection for pod %q: Pod not running\n", pod.Name)
+		return nil
+	}
+
+	// gather data for each container in the given pod
+	for _, container := range pod.Spec.Containers {
+		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering container data for pod %s:\n\n    %v", pod.Name, errors.NewAggregate(errs))
+	}
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerInfo(destDir string, pod *corev1.Pod, container corev1.Container) error {
+	if err := o.gatherContainerAllLogs(path.Join(destDir, "/"+container.Name), pod, &container); err != nil {
+		return err
+	}
+
+	if len(container.Ports) == 0 {
+		log.Printf("        Skipping container endpoint collection for pod %q container %q: No ports\n", pod.Name, container.Name)
+		return nil
+	}
+	port := &util.RemoteContainerPort{
+		Protocol: "https",
+		Port:     container.Ports[0].ContainerPort,
+	}
+
+	if err := o.gatherContainerEndpoints(path.Join(destDir, "/"+container.Name), pod, &container, port); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerAllLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	errs := []error{}
+	if err := o.gatherContainerLogs(path.Join(destDir, "/logs"), pod, container); err != nil {
+		errs = append(errs, filterContainerLogsErrors(err))
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerEndpoints(destDir string, pod *corev1.Pod, container *corev1.Container, metricsPort *util.RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	errs := []error{}
+	if err := o.gatherContainerHealthz(path.Join(destDir, "/healthz"), pod, metricsPort); err != nil {
+		errs = append(errs, err)
+	}
+	if err := o.gatherContainerVersion(destDir, pod, metricsPort); err != nil {
+		errs = append(errs, err)
+	}
+	if err := o.gatherContainerMetrics(destDir, pod, metricsPort); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+func filterContainerLogsErrors(err error) error {
+	if strings.Contains(err.Error(), "previous terminated container") && strings.HasSuffix(err.Error(), "not found") {
+		log.Printf("        Unable to gather previous container logs: %v\n", err)
+		return nil
+	}
+	return err
+}
+
+func (o *InspectOptions) gatherContainerVersion(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	hasVersionPath := false
+
+	// determine if a /version endpoint exists
+	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		if p != "/version" {
+			continue
+		}
+		hasVersionPath = true
+		break
+	}
+	if !hasVersionPath {
+		log.Printf("        Skipping /version info gathering for pod %q. Endpoint not found...\n", pod.Name)
+		return nil
+	}
+
+	result, err := o.podUrlGetter.Get("/version", pod, o.restConfig, metricsPort)
+
+	filename := fmt.Sprintf("%s.json", "metrics")
+	return o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result})
+}
+
+// gatherContainerMetrics invokes an asynchronous network call
+func (o *InspectOptions) gatherContainerMetrics(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	// we need a token in order to access the /metrics endpoint
+	result, err := o.podUrlGetter.Get("/metrics", pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s.json", "metrics")
+	return o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result})
+}
+
+func (o *InspectOptions) gatherContainerHealthz(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+
+	healthzSeparator := "/healthz"
+	healthzPaths := []string{}
+	for _, p := range paths {
+		if !strings.HasPrefix(p, healthzSeparator) {
+			continue
+		}
+		healthzPaths = append(healthzPaths, p)
+	}
+	if len(healthzPaths) == 0 {
+		return fmt.Errorf("unable to find any available /healthz paths hosted in pod %q", pod.Name)
+	}
+
+	for _, healthzPath := range healthzPaths {
+		result, err := o.podUrlGetter.Get(path.Join("/", healthzPath), pod, o.restConfig, metricsPort)
+		if err != nil {
+			// TODO: aggregate errors
+			return err
+		}
+
+		if len(healthzSeparator) > len(healthzPath) {
+			continue
+		}
+		filename := healthzPath[len(healthzSeparator):]
+		if len(filename) == 0 {
+			filename = "index"
+		} else {
+			filename = strings.TrimPrefix(filename, "/")
+		}
+
+		filenameSegs := strings.Split(filename, "/")
+		if len(filenameSegs) > 1 {
+			// ensure directory structure for nested paths exists
+			filenameSegs = filenameSegs[:len(filenameSegs)-1]
+			if err := os.MkdirAll(path.Join(destDir, "/"+strings.Join(filenameSegs, "/")), os.ModePerm); err != nil {
+				return err
+			}
+		}
+
+		if err := o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAvailablePodEndpoints(urlGetter *util.PortForwardURLGetter, pod *corev1.Pod, config *rest.Config, port *util.RemoteContainerPort) ([]string, error) {
+	result, err := urlGetter.Get("/", pod, config, port)
+	if err != nil {
+		return nil, err
+	}
+
+	resultBuffer := bytes.NewBuffer([]byte(result))
+	pathInfo := map[string][]string{}
+
+	// first, unmarshal result into json object and obtain all available /healthz endpoints
+	if err := json.Unmarshal(resultBuffer.Bytes(), &pathInfo); err != nil {
+		return nil, err
+	}
+	paths, ok := pathInfo["paths"]
+	if !ok {
+		return nil, fmt.Errorf("unable to extract path information for pod %q", pod.Name)
+	}
+
+	return paths, nil
+}
+
+func (o *InspectOptions) gatherContainerLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	logOptions := &corev1.PodLogOptions{
+		Container:  container.Name,
+		Follow:     false,
+		Previous:   false,
+		Timestamps: true,
+	}
+	// first, retrieve current logs
+	logsReq := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+
+	filename := fmt.Sprintf("%s.log", "current")
+
+	if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
+		return err
+	}
+
+	// then, retrieve previous logs
+	logOptions.Previous = true
+	logsReqPrevious := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+
+	filename = fmt.Sprintf("%s.log", "previous")
+	return o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReqPrevious)
+}

--- a/pkg/cmd/inspect/resource.go
+++ b/pkg/cmd/inspect/resource.go
@@ -1,26 +1,21 @@
 package inspect
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path"
-	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
-	"k8s.io/client-go/rest"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/route"
 	"github.com/openshift/must-gather/pkg/util"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -40,13 +35,13 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 	}
 	context.visited.Insert(infoToContextKey(info))
 
-	unstr, ok := info.Object.(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("unexpected type. Expecting %q but got %T", "*unstructured.Unstructured", info.Object)
-	}
-
 	switch info.ResourceMapping().Resource.GroupResource() {
 	case configv1.GroupVersion.WithResource("clusteroperators").GroupResource():
+		unstr, ok := info.Object.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected type. Expecting %q but got %T", "*unstructured.Unstructured", info.Object)
+		}
+
 		// first, gather config.openshift.io resource data
 		errs := []error{}
 		if err := o.gatherConfigResourceData(path.Join(o.baseDir, "/cluster-scoped-resources/config.openshift.io"), context); err != nil {
@@ -86,26 +81,49 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 			}
 		}
 
-		if len(errs) > 0 {
-			return errors.NewAggregate(errs)
-		}
+		return errors.NewAggregate(errs)
+
 	case corev1.SchemeGroupVersion.WithResource("namespaces").GroupResource():
+		errs := []error{}
 		if err := o.gatherNamespaceData(o.baseDir, info.Name); err != nil {
-			return err
+			errs = append(errs, err)
 		}
+		resourcesToCollect := namespaceResourcesToCollect()
+		for _, resource := range resourcesToCollect {
+			if context.visited.Has(resourceToContextKey(resource, info.Name)) {
+				continue
+			}
+			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			for _, resourceInfo := range resourceInfos {
+				if err := InspectResource(resourceInfo, context, o); err != nil {
+					errs = append(errs, err)
+					continue
+				}
+			}
+		}
+
+		return errors.NewAggregate(errs)
+
+	case corev1.SchemeGroupVersion.WithResource("secrets").GroupResource(),
+		schema.GroupResource{Group: "route.openshift.io", Resource: "routes"}:
+		// TODO, re-secure these
+		fallthrough
+
 	default:
 		// save the current object to disk
-		filename := fmt.Sprintf("%s.yaml", unstr.GetName())
 		dirPath := dirPathForInfo(o.baseDir, info)
+		filename := filenameForInfo(info)
 		// ensure destination path exists
 		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 			return err
 		}
 
-		return o.fileWriter.WriteFromResource(path.Join(dirPath, "/"+filename), info.Object)
+		return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), info.Object)
 	}
-
-	return nil
 }
 
 func gatherClusterOperatorResource(baseDir string, obj *unstructured.Unstructured, fileWriter *util.MultiSourceFileWriter) error {
@@ -137,398 +155,4 @@ func obtainClusterOperatorRelatedObjects(obj *unstructured.Unstructured) ([]*con
 	}
 
 	return relatedObjs, nil
-}
-
-func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
-	log.Printf("Gathering data for ns/%s...\n", namespace)
-
-	destDir := path.Join(baseDir, namespaceResourcesDirname, namespace)
-
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	ns, err := o.kubeClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
-	if err != nil { // If we can't get the namespace we need to exit out
-		return err
-	}
-	ns.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
-
-	errs := []error{}
-	// write namespace.yaml file
-	filename := fmt.Sprintf("%s.yaml", namespace)
-	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), ns); err != nil {
-		errs = append(errs, err)
-	}
-
-	log.Printf("    Collecting resources for namespace %q...\n", namespace)
-
-	// "all" maps to every resource we wish to collect for the given namespace,
-	// except for "events", "configmaps" and "secrets" so we'll gather those manually.
-	b := resource.NewBuilder(o.configFlags).
-		Unstructured().
-		ResourceTypeOrNameArgs(false, "all").
-		NamespaceParam(namespace).
-		SelectAllParam(true).
-		Latest()
-
-	infos, err := b.Do().Infos()
-	if err != nil {
-		return err
-	}
-
-	resourcesTypesToStore := map[schema.GroupVersionResource]bool{
-		corev1.SchemeGroupVersion.WithResource("events"):     true,
-		corev1.SchemeGroupVersion.WithResource("configmaps"): true,
-	}
-	resourcesToStore := map[schema.GroupVersionResource]runtime.Object{}
-
-	// collect specific resource information for namespace
-	for gvr := range resourcesTypesToStore {
-		list, err := o.dynamicClient.Resource(gvr).Namespace(namespace).List(metav1.ListOptions{})
-		if err != nil {
-			errs = append(errs, err)
-		}
-		resourcesToStore[gvr] = list
-	}
-
-	// iterate over resource builder infos and add resource lists to our store
-	for _, info := range infos {
-		// skip routes, we'll collect those manually below and redact their secret info
-		if info.ResourceMapping().Resource.Resource == "routes" {
-			continue
-		}
-
-		resourcesToStore[info.Mapping.Resource] = info.Object
-	}
-
-	// store redacted secrets
-	secrets, err := o.dynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("secrets")).Namespace(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		errs = append(errs, err)
-	}
-	secretsToStore := []unstructured.Unstructured{}
-	for _, secret := range secrets.Items {
-		if _, ok := secret.Object["data"]; ok {
-			secret.Object["data"] = nil
-		}
-		secretsToStore = append(secretsToStore, secret)
-	}
-	secrets.Items = secretsToStore
-	resourcesToStore[corev1.SchemeGroupVersion.WithResource("secrets")] = secrets
-
-	// store redacted routes
-	routes, err := o.dynamicClient.Resource(schema.GroupVersionResource{Group: route.GroupName, Version: "v1", Resource: "routes"}).Namespace(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		errs = append(errs, err)
-	}
-	routesToStore := []unstructured.Unstructured{}
-	for _, route := range routes.Items {
-		// TODO, you only want to remove the key
-		if _, ok := route.Object["tls"]; ok {
-			route.Object["tls"] = nil
-		}
-		routesToStore = append(routesToStore, route)
-	}
-	routes.Items = routesToStore
-	resourcesToStore[schema.GroupVersionResource{Group: route.GroupName, Version: "v1", Resource: "routes"}] = routes
-
-	for gvr, obj := range resourcesToStore {
-		filename := gvr.Resource
-		if len(gvr.Group) > 0 {
-			filename += "." + gvr.Group
-		}
-		filename += ".yaml"
-		if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), obj); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	log.Printf("    Gathering pod data for namespace %q...\n", namespace)
-
-	// gather specific pod data
-	for _, pod := range resourcesToStore[corev1.SchemeGroupVersion.WithResource("pods")].(*unstructured.UnstructuredList).Items {
-		log.Printf("        Gathering data for pod %q\n", pod.GetName())
-		structuredPod := &corev1.Pod{}
-		runtime.DefaultUnstructuredConverter.FromUnstructured(pod.Object, structuredPod)
-		if err := o.gatherPodData(path.Join(destDir, "/pods/"+pod.GetName()), namespace, structuredPod); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
-	}
-	return nil
-}
-
-func (o *InspectOptions) gatherPodData(destDir, namespace string, pod *corev1.Pod) error {
-	if pod.Status.Phase != corev1.PodRunning {
-		log.Printf("        Skipping container data collection for pod %q: Pod not running\n", pod.Name)
-		return nil
-	}
-
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	filename := fmt.Sprintf("%s.yaml", pod.Name)
-	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), pod); err != nil {
-		return err
-	}
-
-	errs := []error{}
-
-	// skip gathering container data if containers are no longer running
-	if running, err := util.PodRunningReady(pod); err != nil {
-		return err
-	} else if !running {
-		log.Printf("        Skipping container data collection for pod %q: Pod not running\n", pod.Name)
-		return nil
-	}
-
-	// gather data for each container in the given pod
-	for _, container := range pod.Spec.Containers {
-		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-	}
-	for _, container := range pod.Spec.InitContainers {
-		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("one or more errors ocurred while gathering container data for pod %s:\n\n    %v", pod.Name, errors.NewAggregate(errs))
-	}
-	return nil
-}
-
-func (o *InspectOptions) gatherContainerInfo(destDir string, pod *corev1.Pod, container corev1.Container) error {
-	if err := o.gatherContainerAllLogs(path.Join(destDir, "/"+container.Name), pod, &container); err != nil {
-		return err
-	}
-
-	if len(container.Ports) == 0 {
-		log.Printf("        Skipping container endpoint collection for pod %q container %q: No ports\n", pod.Name, container.Name)
-		return nil
-	}
-	port := &util.RemoteContainerPort{
-		Protocol: "https",
-		Port:     container.Ports[0].ContainerPort,
-	}
-
-	if err := o.gatherContainerEndpoints(path.Join(destDir, "/"+container.Name), pod, &container, port); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (o *InspectOptions) gatherContainerAllLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	errs := []error{}
-	if err := o.gatherContainerLogs(path.Join(destDir, "/logs"), pod, container); err != nil {
-		errs = append(errs, filterContainerLogsErrors(err))
-	}
-
-	if len(errs) > 0 {
-		return errors.NewAggregate(errs)
-	}
-	return nil
-}
-
-func (o *InspectOptions) gatherContainerEndpoints(destDir string, pod *corev1.Pod, container *corev1.Container, metricsPort *util.RemoteContainerPort) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	errs := []error{}
-	if err := o.gatherContainerHealthz(path.Join(destDir, "/healthz"), pod, metricsPort); err != nil {
-		errs = append(errs, err)
-	}
-	if err := o.gatherContainerVersion(destDir, pod, metricsPort); err != nil {
-		errs = append(errs, err)
-	}
-	if err := o.gatherContainerMetrics(destDir, pod, metricsPort); err != nil {
-		errs = append(errs, err)
-	}
-
-	if len(errs) > 0 {
-		return errors.NewAggregate(errs)
-	}
-	return nil
-}
-
-func filterContainerLogsErrors(err error) error {
-	if strings.Contains(err.Error(), "previous terminated container") && strings.HasSuffix(err.Error(), "not found") {
-		log.Printf("        Unable to gather previous container logs: %v\n", err)
-		return nil
-	}
-	return err
-}
-
-func (o *InspectOptions) gatherContainerVersion(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	hasVersionPath := false
-
-	// determine if a /version endpoint exists
-	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
-	if err != nil {
-		return err
-	}
-	for _, p := range paths {
-		if p != "/version" {
-			continue
-		}
-		hasVersionPath = true
-		break
-	}
-	if !hasVersionPath {
-		log.Printf("        Skipping /version info gathering for pod %q. Endpoint not found...\n", pod.Name)
-		return nil
-	}
-
-	result, err := o.podUrlGetter.Get("/version", pod, o.restConfig, metricsPort)
-
-	filename := fmt.Sprintf("%s.json", "metrics")
-	return o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result})
-}
-
-// gatherContainerMetrics invokes an asynchronous network call
-func (o *InspectOptions) gatherContainerMetrics(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	// we need a token in order to access the /metrics endpoint
-	result, err := o.podUrlGetter.Get("/metrics", pod, o.restConfig, metricsPort)
-	if err != nil {
-		return err
-	}
-
-	filename := fmt.Sprintf("%s.json", "metrics")
-	return o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result})
-}
-
-func (o *InspectOptions) gatherContainerHealthz(destDir string, pod *corev1.Pod, metricsPort *util.RemoteContainerPort) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
-	if err != nil {
-		return err
-	}
-
-	healthzSeparator := "/healthz"
-	healthzPaths := []string{}
-	for _, p := range paths {
-		if !strings.HasPrefix(p, healthzSeparator) {
-			continue
-		}
-		healthzPaths = append(healthzPaths, p)
-	}
-	if len(healthzPaths) == 0 {
-		return fmt.Errorf("unable to find any available /healthz paths hosted in pod %q", pod.Name)
-	}
-
-	for _, healthzPath := range healthzPaths {
-		result, err := o.podUrlGetter.Get(path.Join("/", healthzPath), pod, o.restConfig, metricsPort)
-		if err != nil {
-			// TODO: aggregate errors
-			return err
-		}
-
-		if len(healthzSeparator) > len(healthzPath) {
-			continue
-		}
-		filename := healthzPath[len(healthzSeparator):]
-		if len(filename) == 0 {
-			filename = "index"
-		} else {
-			filename = strings.TrimPrefix(filename, "/")
-		}
-
-		filenameSegs := strings.Split(filename, "/")
-		if len(filenameSegs) > 1 {
-			// ensure directory structure for nested paths exists
-			filenameSegs = filenameSegs[:len(filenameSegs)-1]
-			if err := os.MkdirAll(path.Join(destDir, "/"+strings.Join(filenameSegs, "/")), os.ModePerm); err != nil {
-				return err
-			}
-		}
-
-		if err := o.fileWriter.WriteFromSource(path.Join(destDir, filename), &util.TextWriterSource{Text: result}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getAvailablePodEndpoints(urlGetter *util.PortForwardURLGetter, pod *corev1.Pod, config *rest.Config, port *util.RemoteContainerPort) ([]string, error) {
-	result, err := urlGetter.Get("/", pod, config, port)
-	if err != nil {
-		return nil, err
-	}
-
-	resultBuffer := bytes.NewBuffer([]byte(result))
-	pathInfo := map[string][]string{}
-
-	// first, unmarshal result into json object and obtain all available /healthz endpoints
-	if err := json.Unmarshal(resultBuffer.Bytes(), &pathInfo); err != nil {
-		return nil, err
-	}
-	paths, ok := pathInfo["paths"]
-	if !ok {
-		return nil, fmt.Errorf("unable to extract path information for pod %q", pod.Name)
-	}
-
-	return paths, nil
-}
-
-func (o *InspectOptions) gatherContainerLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
-	// ensure destination path exists
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	logOptions := &corev1.PodLogOptions{
-		Container:  container.Name,
-		Follow:     false,
-		Previous:   false,
-		Timestamps: true,
-	}
-	// first, retrieve current logs
-	logsReq := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
-
-	filename := fmt.Sprintf("%s.log", "current")
-
-	if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
-		return err
-	}
-
-	// then, retrieve previous logs
-	logOptions.Previous = true
-	logsReqPrevious := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
-
-	filename = fmt.Sprintf("%s.log", "previous")
-	return o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReqPrevious)
 }


### PR DESCRIPTION


This separates the namespace configs by group and makes the namespace detection go through the polymorphic path.

```
└── namespaces
    ├── openshift-config
    │   ├── apps
    │   │   ├── daemonsets.yaml
    │   │   ├── deployments.yaml
    │   │   ├── replicasets.yaml
    │   │   └── statefulsets.yaml
    │   ├── apps.openshift.io
    │   │   └── deploymentconfigs.yaml
    │   ├── autoscaling
    │   │   └── horizontalpodautoscalers.yaml
    │   ├── batch
    │   │   ├── cronjobs.yaml
    │   │   └── jobs.yaml
    │   ├── build.openshift.io
    │   │   ├── buildconfigs.yaml
    │   │   └── builds.yaml
    │   ├── core
    │   │   ├── configmaps.yaml
    │   │   ├── events.yaml
    │   │   ├── pods.yaml
    │   │   ├── replicationcontrollers.yaml
    │   │   ├── secrets.yaml
    │   │   └── services.yaml
    │   ├── image.openshift.io
    │   │   └── imagestreams.yaml
    │   ├── openshift-config.yaml
    │   └── route.openshift.io
    │       └── routes.yaml

```

/assign @juanvallejo 