### PR TITLE
dump group and serving info for certs

### DIFF
--- a/pkg/cmd/certinspection/certinspection.go
+++ b/pkg/cmd/certinspection/certinspection.go
@@ -228,5 +228,22 @@ func certDetail(certificate *x509.Certificate) string {
 		usages = append(usages, fmt.Sprintf("%d", curr))
 	}
 
-	return fmt.Sprintf("%q [%s] issuer=%q (%v to %v)", humanName, strings.Join(usages, ","), signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC())
+	validServingNames := []string{}
+	for _, ip := range certificate.IPAddresses {
+		validServingNames = append(validServingNames, ip.String())
+	}
+	for _, dnsName := range certificate.DNSNames {
+		validServingNames = append(validServingNames, dnsName)
+	}
+	servingString := ""
+	if len(validServingNames) > 0 {
+		servingString = fmt.Sprintf(" validServingFor=[%s]", strings.Join(validServingNames, ","))
+	}
+
+	groupString := ""
+	if len(certificate.Subject.Organization) > 0 {
+		groupString = fmt.Sprintf(" groups=[%s]", strings.Join(certificate.Subject.Organization, ","))
+	}
+
+	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v)", humanName, strings.Join(usages, ","), groupString, servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC())
 }


### PR DESCRIPTION
Let's us see SANs and groups:

```
secrets/initial-serving-cert[openshift-config] - tls (2019-02-22 13:59:00 +0000 UTC)
    "system:kube-apiserver" [serving,client] groups=[kube-master] validFor=[172.30.0.1,127.0.0.1,api.ci-ln-q8f6ipk-703b0.origin-ci-int-aws.dev.rhcloud.com,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local,localhost] issuer="kube-ca" (2019-02-22 13:50:41 +0000 UTC to 2029-02-19 13:50:48 +0000 UTC)
    "kube-ca" [] issuer="<self>" (2019-02-22 13:50:41 +0000 UTC to 2029-02-19 13:50:41 +0000 UTC)

```

/assign @soltysh 