### PR TITLE
change must-gather image base FROM base to cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 ENV GO_PACKAGE github.com/openshift/must-gather
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/openshift-must-gather
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/openshift-must-gather /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,6 +4,6 @@ COPY . .
 ENV GO_PACKAGE github.com/openshift/must-gather
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/openshift-must-gather
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.0:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/openshift-must-gather /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
Change the base image used when running `make images` locally to better match what gets built during a release build.