### PR TITLE
Add --by=resource output

### DIFF
--- a/pkg/cmd/audit/audit.go
+++ b/pkg/cmd/audit/audit.go
@@ -151,6 +151,8 @@ func (o *AuditOptions) Run() error {
 			PrintTopByVerbAuditEvents(o.Out, events)
 		case "user":
 			PrintTopByUserAuditEvents(o.Out, events)
+		case "resource":
+			PrintTopByResourceAuditEvents(o.Out, events)
 		default:
 			return fmt.Errorf("unsupported -by value")
 		}

--- a/pkg/cmd/audit/io.go
+++ b/pkg/cmd/audit/io.go
@@ -31,7 +31,15 @@ func PrintAuditEvents(writer io.Writer, events []*auditv1.Event) {
 		if event.ResponseStatus != nil {
 			code = event.ResponseStatus.Code
 		}
-		fmt.Fprintf(w, "%s [%s][%s] [%d]\t %s\t [%s]\n", event.RequestReceivedTimestamp.Format("15:04:05"), strings.ToUpper(event.Verb), duration, code, event.RequestURI, event.User.Username)
+		if _, err := fmt.Fprintf(w, "%s [%6s][%12s] [%3d]\t %s\t [%s]\n",
+			event.RequestReceivedTimestamp.Format("15:04:05"),
+			strings.ToUpper(event.Verb),
+			duration,
+			code,
+			event.RequestURI,
+			event.User.Username); err != nil {
+			panic(err)
+		}
 	}
 }
 
@@ -46,8 +54,14 @@ func PrintAuditEventsWithCount(writer io.Writer, events []*eventWithCounter) {
 		if event.event.ResponseStatus != nil {
 			code = event.event.ResponseStatus.Code
 		}
-		fmt.Fprintf(w, "%dx %s [%s][%s] [%d]\t %s\t [%s]\n", event.count, event.event.RequestReceivedTimestamp.Format("15:04:05"), strings.ToUpper(event.event.Verb), duration, code, event.event.RequestURI,
-			event.event.User.Username)
+		if _, err := fmt.Fprintf(w, "%8s [%12s] [%3d]\t %s\t [%s]\n",
+			fmt.Sprintf("%dx", event.count),
+			duration,
+			code,
+			event.event.RequestURI,
+			event.event.User.Username); err != nil {
+			panic(err)
+		}
 	}
 }
 
@@ -61,7 +75,16 @@ func PrintAuditEventsWide(writer io.Writer, events []*auditv1.Event) {
 		if event.ResponseStatus != nil {
 			code = event.ResponseStatus.Code
 		}
-		fmt.Fprintf(w, "%s (%v) [%s][%s] [%d]\t %s\t [%s]\n", event.RequestReceivedTimestamp.Format("15:04:05"), event.AuditID, strings.ToUpper(event.Verb), duration, code, event.RequestURI, event.User.Username)
+		if _, err := fmt.Fprintf(w, "%s (%v) [%s][%s] [%d]\t %s\t [%s]\n",
+			event.RequestReceivedTimestamp.Format("15:04:05"),
+			event.AuditID,
+			strings.ToUpper(event.Verb),
+			duration,
+			code,
+			event.RequestURI,
+			event.User.Username); err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Sample:

```
❯ ./openshift-dev-helpers audit -f ~/xxx/audit -o top --by=resource
73425x               v1/secrets
24507x               v1/nodes
20497x               v1/configmaps
4729x                v1/pods
3378x                v1/persistentvolumes
3356x                v1/persistentvolumeclaims
2499x                authentication.k8s.io/v1beta1/tokenreviews
1599x                v1/serviceaccounts
1240x                v1/services
1120x                v1/events
955x                 v1/endpoints
817x                 network.openshift.io/v1/hostsubnets
813x                 network.openshift.io/v1/netnamespaces
752x                 apiregistration.k8s.io/v1/apiservices
731x                 network.openshift.io/v1/egressnetworkpolicies
692x                 authorization.k8s.io/v1beta1/subjectaccessreviews
174x                 oauth.openshift.io/v1/oauthaccesstokens
172x                 user.openshift.io/v1/users

```