### PR TITLE
fix(oc-must-gather,oc-dev-helper): cli should show available sub cmds

### DIFF
--- a/cmd/openshift-dev-helpers/main.go
+++ b/cmd/openshift-dev-helpers/main.go
@@ -46,7 +46,7 @@ func NewCmdDevHelpers(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			return nil
+			return c.Help()
 		},
 	}
 

--- a/cmd/openshift-must-gather/main.go
+++ b/cmd/openshift-must-gather/main.go
@@ -39,7 +39,7 @@ func NewCmdMustGather(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			return nil
+			return c.Help()
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: ashishranjan738 <ashishranjan738@gmail.com>

This commit enables showing of available sub commands when no or invalid subcommands are passed

Output:

```
[aranjan@ashish-pc must-gather]$ ./openshift-must-gather
Gather debugging data for a given cluster operator

Usage:
  openshift-must-gather [command]

Available Commands:
  help        Help about any command
  inspect     Collect debugging data for a given cluster operator

Flags:
  -h, --help   help for openshift-must-gather

Use "openshift-must-gather [command] --help" for more information about a command.
```

```
[aranjan@ashish-pc must-gather]$ ./openshift-dev-helpers
Set of helpers for OpenShift developer teams

Usage:
  openshift-dev-helpers [command]

Available Commands:
  analyze-e2e     Inspects the artifacts gathered during e2e-aws run and analyze them.
  audit           Inspects the audit logs captured during CI test run.
  event           Inspects the event logs captured during CI test run.
  help            Help about any command
  inspect-certs   Inspects the certs, keys, and ca-bundles in a set of resources.
  revision-status Counts failed installer pods and current revision of static pods.

Flags:
  -h, --help   help for openshift-dev-helpers

Use "openshift-dev-helpers [command] --help" for more information about a command.
```