### PR TITLE
Revert "Bug 1715634: ensure we collect cluster version information"

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -3,9 +3,6 @@
 # Resource List
 resources=()
 
-# Cluster Version Information 
-resources+=(clusterversion ns/openshift-cluster-version)
-
 # Operator Resources
 resources+=(clusteroperators)
 


### PR DESCRIPTION
Reverts openshift/must-gather#96

This was merged without arhictect approval for an unapproved bug at an unapproved time. Do not do this again.