### PR TITLE
Bug 1720321 - must-gather does not collect all non-core CRs in the given namespace

### DIFF
--- a/pkg/cmd/inspect/resource.go
+++ b/pkg/cmd/inspect/resource.go
@@ -69,15 +69,17 @@ func InspectResource(info *resource.Info, context *resourceContext, o *InspectOp
 				continue
 			}
 
-			relatedInfo, err := objectReferenceToResourceInfo(o.configFlags, relatedRef)
+			relatedInfos, err := objectReferenceToResourceInfos(o.configFlags, relatedRef)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
 
-			if err := InspectResource(relatedInfo, context, o); err != nil {
-				errs = append(errs, err)
-				continue
+			for _, relatedInfo := range relatedInfos {
+				if err := InspectResource(relatedInfo, context, o); err != nil {
+					errs = append(errs, err)
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION
When empty `Name` and/or `Namespace` values are specified in a `ClusterOperator.spec.relatedObjects` gather everything that matches the non-empty field that are specified.

For example, the following entry in `ClusterOperator.spec.relatedObjects` would collect all `CatalogSources` in the `openshift-marketplace` namespace:
```
status:
  relatedObjects:
  - group:     operators.coreos.com
    namespace: openshift-marketplace
    resource:  catalogsources
```

https://bugzilla.redhat.com/show_bug.cgi?id=1720321
