### PR TITLE
Bug 1722548: collection-scripts/gather: add ns/openshift-etcd

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -16,7 +16,7 @@ resources+=(certificatesigningrequests)
 resources+=(nodes machines machineconfigs machineconfigpools)
 
 # Namespaces/Project Resources
-resources+=(ns/default ns/openshift ns/kube-system)
+resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
 
 # Storage Resources
 resources+=(storageclasses persistentvolumes volumeattachments)


### PR DESCRIPTION
Debugging issues with the cluster require access to etcd-member container logging. This PR adds `openshift-etcd` namespace to the resource list.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1722548