### PR TITLE
Bug 1723472: must-gather should redact kubectl.kubernetes.io/last-applied-configuration in secrets

### DIFF
--- a/pkg/cmd/inspect/secret.go
+++ b/pkg/cmd/inspect/secret.go
@@ -84,4 +84,7 @@ func elideSecret(secret *corev1.Secret) {
 	if _, ok := secret.Annotations["openshift.io/token-secret.value"]; ok {
 		secret.Annotations["openshift.io/token-secret.value"] = ""
 	}
+	if _, ok := secret.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		secret.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = ""
+	}
 }


### PR DESCRIPTION
Redact the `kubectl.kubernetes.io/last-applied-configuration` in Secrets to avoid exposing non-public data Secrets after an `oc apply -f` update.