### PR TITLE
Don't gather openshift-sdn-specific networking resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -22,7 +22,7 @@ resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
 resources+=(storageclasses persistentvolumes volumeattachments)
 
 # Networking Resources
-resources+=(clusternetworks hostsubnets)
+resources+=(networks.operator.openshift.io)
 
 # Autoscaler Resources
 resources+=(clusterautoscaler machineautoscaler)


### PR DESCRIPTION
Otherwise the command will exit with an error when running with ovn-kubernetes or any other network plugin. (eg, this breaks the test `[cli] oc adm must-gather runs successfully [Suite:openshift/conformance/parallel]` in e2e-aws-ovn-kubernetes)

The clusternetwork object is redundant if we have network.operators.openshift.io anyway. It would be nice to collect the hostsubnet objects if and only if they existed, but maybe that can be added later. (We're going to want to add some ovn-kubernetes-specific stuff for only when ovn-kubernetes is running as well.)