### PR TITLE
generate /must-gather/version file

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# generate /must-gather/version file
+. version
+echo "openshift/must-gather" > /must-gather/version
+version >> /must-gather/version
+
 # Resource List
 resources=()
 

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function version() {
+  # get version from image
+  version=$( \
+    oc status | grep '^pod' | \
+    sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
+  )
+
+  # if version not found, fallback to imageID
+  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
+
+  # if version still not found, use Unknown
+  [ -z "${version}" ] && version="Unknown"
+
+  echo ${version}
+}


### PR DESCRIPTION
Conform to must-gather spec: https://github.com/openshift/enhancements/blame/master/must-gather.md#L113

Sample output:
```
openshift/must-gather
4.2-2019-09-19-151434
```
If the version can't be determined from the image id, the entire image id is provided instead.