### PR TITLE
Bug 1862426: gather the audit logs for oauth apiserver

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -41,9 +41,6 @@ done
 # Gather etcd information
 /usr/bin/gather_etcd
 
-# Collect System Audit Logs
-/usr/bin/gather_audit_logs
-
 # Gather Service Logs (using a suplamental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
 

--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -1,40 +1,29 @@
 #!/bin/bash
-BASE_COLLECTION_PATH="/must-gather"
-AUDIT_LOG_PATH="${BASE_COLLECTION_PATH}/audit_logs/"
-
-### Helper Functions
-function queue() {
-    local TARGET="${1}"
-    shift
-    local LIVE="$(jobs | wc -l)"
-    while [[ "${LIVE}" -ge 45 ]]; do
-        sleep 1
-	LIVE="$(jobs | wc -l)"
-    done
-    echo "${@}"
-    if [[ -n "${FILTER}" ]]; then
-        "${@}" | "${FILTER}" >"${TARGET}" &
-    else
-        "${@}" >"${TARGET}" &
-    fi
-}
-
-# Collect System Audit Logs
-function collect_audit_logs {  ### Takes an input of PATH
-                               ###  (openshift-apiserver or kube-apiserver)
-
-    echo "WARNING: Collecting one or more audit logs on ALL masters in your cluster. This could take a large amount of time." >&2
-    mkdir -p ${AUDIT_LOG_PATH}/${1}
-    /usr/bin/oc adm node-logs --role=master --path=${1}/ | grep -v ".terminating" > ${AUDIT_LOG_PATH}/${1}.audit_logs_listing
-    while IFS=$'\n' read -r line; do
-        IFS=' ' read -ra log <<< "${line}"
-	FILTER=gzip queue ${AUDIT_LOG_PATH}/${1}/"${log[0]}"-"${log[1]}".gz /usr/bin/oc adm node-logs "${log[0]}" --path=${1}/"${log[1]}"
-    done < ${AUDIT_LOG_PATH}/${1}.audit_logs_listing
-    echo "INFO: Audit logs for $1 collected."
-}
-
-collect_audit_logs openshift-apiserver
-collect_audit_logs kube-apiserver
+# Downloads the audit.log (and its rotated copies) from
+# /var/logs/{kube-apiserver,openshift-apiserver} on each
+# master node.
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+echo "WARNING: Collecting one or more audit logs on ALL masters in your cluster. This could take a large amount of time." >&2
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+paths=(openshift-apiserver kube-apiserver oauth-apiserver)
+for path in "${paths[@]}" ; do
+  output_dir="${BASE_COLLECTION_PATH}/audit_logs/$path"
+  mkdir -p "$output_dir"
+  oc adm node-logs --role=master --path="$path" | \
+  tee "${BASE_COLLECTION_PATH}/audit_logs/$path.audit_logs_listing" | \
+  grep -v ".terminating" | \
+  sed "s|^|$path $output_dir |"
+done | \
+xargs --max-args=4 --max-procs=45 bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+echo "INFO: Audit logs collected."
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_service_logs
+++ b/collection-scripts/gather_service_logs
@@ -16,14 +16,14 @@ function collect_serivce_logs {  ## Takes a node role input (master or worker)
     PIDS=()
     DIR_PATH=${SERVICE_LOG_PATH}/${1}s
     echo "WARNING: Collecting one or more service logs on ALL linux $1 nodes in your cluster. This could take a large amount of time." >&2
-    mkdir -p ${DIR_PATH}
-    for service in ${NODE_SERVICES[@]}; do
+    mkdir -p "${DIR_PATH}"
+    for service in "${NODE_SERVICES[@]}"; do
         echo "INFO: Collecting host service logs for $service"
-        /usr/bin/oc adm node-logs --role=$1 -l kubernetes.io/os=linux -u $service > ${DIR_PATH}/${service}_service.log &
+        /usr/bin/oc adm node-logs --role=$1 -l kubernetes.io/os=linux -u "$service" --since "${SINCE_TIMEFRAME:--7d}"> "${DIR_PATH}/${service}_service.log" &
 	PIDS+=($!)
     done
     echo "INFO: Waiting for worker host service log collection to complete ..."
-    wait ${PIDS[@]}
+    wait "${PIDS[@]}"
     echo "INFO: Worker host service log collection to complete."
 }
 

--- a/collection-scripts/gather_service_logs
+++ b/collection-scripts/gather_service_logs
@@ -3,10 +3,10 @@ BASE_COLLECTION_PATH="/must-gather"
 ROLES=${1:-master}         ### Defaults to only collecting things from Masters
 
 # Service Lists
-GENERAL_SERVICES=(kubelet crio)
-MASTER_SERVICES+=${2:-${GENERAL_SERVICES[@]}}
+GENERAL_SERVICES=(kubelet crio machine-config-daemon-firstboot machine-config-daemon-host)
+MASTER_SERVICES+=(${2:-"${GENERAL_SERVICES[@]}"})
 MASTER_SERVICES+=()        ### Placeholder to extend Master only services
-NODE_SERVICES+=${2:-${GENERAL_SERVICES[@]}}
+NODE_SERVICES+=(${2:-"${GENERAL_SERVICES[@]}"})
 NODE_SERVICES+=()          ### Placeholder to extend Node only services
 
 # Collect System Service Logs


### PR DESCRIPTION
* simplified logic
* added progress logging
* also capture oauth-apiserver logs
* add `SINCE_TIMEFRAME` env, defaulted to `1w`