### PR TITLE
Bug 1829113: Add openshift-kni-infra namespace to gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -21,7 +21,7 @@ resources+=(certificatesigningrequests)
 resources+=(nodes machineconfigs machineconfigpools)
 
 # Namespaces/Project Resources
-resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
+resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)
 
 # Storage Resources
 resources+=(storageclasses persistentvolumes volumeattachments)


### PR DESCRIPTION
openshift-kni-infra is the namespace where baremetal service pods
run. Currently it is not collected by must-gather which can make it
difficult to debug baremetal deployment issues. This adds the
namespace to the list of namespaces from which to collect logs.