### PR TITLE
bug 1834836: gather_network_logs - capture sbdb and nbdb

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -60,7 +60,7 @@ function gather_ovn_kubernetes_nodes_data {
       "ovs-vsctl show" > ${NETWORK_LOG_PATH}/${NODE}_${OVS_NODE_POD}_ovs_dump &
       PIDS+=($!)
 
-      OVNKUBE_MASTER=$(oc --insecure-skip-tls-verify --request-timeout=20s -n openshift-ovn-kubernetes \
+      OVNKUBE_MASTER=$(oc -n openshift-ovn-kubernetes \
           get pods --no-headers -o custom-columns=':metadata.name' --field-selector spec.nodeName=${NODE} -l app=ovnkube-master)
 
       if [[ ${OVNKUBE_MASTER} != "" ]] ; then


### PR DESCRIPTION
This fixes a problem in getting the master pod.

This captures the ovn database files on each master node
It also includes the node name in the file name of the
log files.

Bug 1834836
https://bugzilla.redhat.com/show_bug.cgi?id=1834836

SDN-946 - gather_network_logs - also capture sbdb and nbdb
https://issues.redhat.com/browse/SDN-946

Signed-off-by: Phil Cameron <pcameron@redhat.com>