### PR TITLE
Gather etcd information from must-gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -43,3 +43,6 @@ done
 
 # Gather Service Logs (using a suplamental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
+
+# Gather etcd information
+/usr/bin/gather_etcd

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -38,11 +38,11 @@ for resource in "${resources[@]}"; do
     oc adm inspect --dest-dir must-gather ${resource}
 done
 
+# Gather etcd information
+/usr/bin/gather_etcd
+
 # Collect System Audit Logs
 /usr/bin/gather_audit_logs
 
 # Gather Service Logs (using a suplamental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
-
-# Gather etcd information
-/usr/bin/gather_etcd

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -3,15 +3,15 @@
 BASE_COLLECTION_PATH="/must-gather"
 ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
 
-ETCD_CONTAINER='etcdctl'
+ETCDCTL_CONTAINER='etcdctl'
 
 RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
 
 # We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
-ETCDCTL_ENDPOINTS=$(oc exec ${RUNNING_ETCD_POD}  -n openshift-etcd -c ${ETCD_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
+ETCDCTL_ENDPOINTS=$(oc exec ${RUNNING_ETCD_POD}  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
 
 function ocp4etcdctl {
-    oc -n openshift-etcd exec -c ${ETCD_CONTAINER} ${RUNNING_ETCD_POD} -- env ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS} etcdctl $@
+    oc -n openshift-etcd exec -c ${ETCDCTL_CONTAINER} ${RUNNING_ETCD_POD} -- env ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS} etcdctl $@
 }
 
 if [[ -z $RUNNING_ETCD_POD ]];then
@@ -19,7 +19,7 @@ if [[ -z $RUNNING_ETCD_POD ]];then
     exit 1
 fi
 
-echo "Getting information from pod \"${RUNNING_ETCD_POD}\", container \"${ETCD_CONTAINER}\""
+echo "Getting information from pod \"${RUNNING_ETCD_POD}\", container \"${ETCDCTL_CONTAINER}\""
 echo "Using endpoints: ${ETCDCTL_ENDPOINTS}"
 
 mkdir -p ${ETCD_LOG_PATH}

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -8,10 +8,10 @@ ETCDCTL_CONTAINER='etcdctl'
 RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
 
 # We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
-ETCDCTL_ENDPOINTS=$(oc exec ${RUNNING_ETCD_POD}  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
+ETCDCTL_ENDPOINTS=$(oc exec "${RUNNING_ETCD_POD}"  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
 
 function ocp4etcdctl {
-    oc -n openshift-etcd exec -c ${ETCDCTL_CONTAINER} ${RUNNING_ETCD_POD} -- env ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS} etcdctl $@
+    oc -n openshift-etcd exec -c "${ETCDCTL_CONTAINER}" "${RUNNING_ETCD_POD}" -- env "ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS}" etcdctl "$@"
 }
 
 if [[ -z $RUNNING_ETCD_POD ]];then
@@ -57,5 +57,5 @@ ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json &
 PIDS+=($!)
 
 echo "INFO: Waiting for etcd info collection to complete ..."
-wait ${PIDS[@]}
+wait "${PIDS[@]}"
 echo "INFO: Done collecting etcd information"

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#Safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
 BASE_COLLECTION_PATH="/must-gather"
 ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
 
@@ -25,6 +30,9 @@ echo "Using endpoints: ${ETCDCTL_ENDPOINTS}"
 mkdir -p ${ETCD_LOG_PATH}
 
 echo "INFO: Starting getting etcd information"
+
+# If one ocp4etcdctl execution fails, the other ones should be tried anyway.
+set +o errexit
 
 PIDS=()
 

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -38,10 +38,6 @@ echo "INFO: Getting etcdctl alarm list"
 ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt
 ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json
 
-# List all etcd keys
-echo "INFO: Getting list of keys in etcd"
-ocp4etcdctl get --keys-only --from-key / > ${ETCD_LOG_PATH}/etcd_keys.txt
-
 # Check perf
 echo "INFO: Performing etcdctl check perf"
 ocp4etcdctl check perf --load="s" > ${ETCD_LOG_PATH}/etcd_check_perf.txt

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -7,8 +7,11 @@ ETCD_CONTAINER='etcdctl'
 
 RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
 
+# We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
+ETCDCTL_ENDPOINTS=$(oc exec ${RUNNING_ETCD_POD}  -n openshift-etcd -c ${ETCD_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
+
 function ocp4etcdctl {
-    oc -n openshift-etcd exec -c ${ETCD_CONTAINER} ${RUNNING_ETCD_POD} -- etcdctl $@
+    oc -n openshift-etcd exec -c ${ETCD_CONTAINER} ${RUNNING_ETCD_POD} -- env ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS} etcdctl $@
 }
 
 if [[ -z $RUNNING_ETCD_POD ]];then
@@ -17,6 +20,7 @@ if [[ -z $RUNNING_ETCD_POD ]];then
 fi
 
 echo "Getting information from pod \"${RUNNING_ETCD_POD}\", container \"${ETCD_CONTAINER}\""
+echo "Using endpoints: ${ETCDCTL_ENDPOINTS}"
 
 mkdir -p ${ETCD_LOG_PATH}
 

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -30,29 +30,21 @@ PIDS=()
 
 # member list
 echo "INFO: Getting etcdctl member list"
-ocp4etcdctl member list -w table > ${ETCD_LOG_PATH}/member_list.txt &
-PIDS+=($!)
 ocp4etcdctl member list -w json > ${ETCD_LOG_PATH}/member_list.json &
 PIDS+=($!)
 
 # endpoint status
 echo "INFO: Getting etcdctl endpoint status"
-ocp4etcdctl endpoint status -w table > ${ETCD_LOG_PATH}/endpoint_status.txt &
-PIDS+=($!)
 ocp4etcdctl endpoint status -w json > ${ETCD_LOG_PATH}/endpoint_status.json &
 PIDS+=($!)
 
 # endpoint health
 echo "INFO: Getting etcdctl endpoint health"
-ocp4etcdctl endpoint health -w table > ${ETCD_LOG_PATH}/endpoint_health.txt &
-PIDS+=($!)
 ocp4etcdctl endpoint health -w json > ${ETCD_LOG_PATH}/endpoint_health.json &
 PIDS+=($!)
 
 # alarm list
 echo "INFO: Getting etcdctl alarm list"
-ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt &
-PIDS+=($!)
 ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json &
 PIDS+=($!)
 

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -26,24 +26,36 @@ mkdir -p ${ETCD_LOG_PATH}
 
 echo "INFO: Starting getting etcd information"
 
+PIDS=()
+
 # member list
 echo "INFO: Getting etcdctl member list"
-ocp4etcdctl member list -w table > ${ETCD_LOG_PATH}/member_list.txt
-ocp4etcdctl member list -w json > ${ETCD_LOG_PATH}/member_list.json
+ocp4etcdctl member list -w table > ${ETCD_LOG_PATH}/member_list.txt &
+PIDS+=($!)
+ocp4etcdctl member list -w json > ${ETCD_LOG_PATH}/member_list.json &
+PIDS+=($!)
 
 # endpoint status
 echo "INFO: Getting etcdctl endpoint status"
-ocp4etcdctl endpoint status -w table > ${ETCD_LOG_PATH}/endpoint_status.txt
-ocp4etcdctl endpoint status -w json > ${ETCD_LOG_PATH}/endpoint_status.json
+ocp4etcdctl endpoint status -w table > ${ETCD_LOG_PATH}/endpoint_status.txt &
+PIDS+=($!)
+ocp4etcdctl endpoint status -w json > ${ETCD_LOG_PATH}/endpoint_status.json &
+PIDS+=($!)
 
 # endpoint health
 echo "INFO: Getting etcdctl endpoint health"
-ocp4etcdctl endpoint health -w table > ${ETCD_LOG_PATH}/endpoint_health.txt
-ocp4etcdctl endpoint health -w json > ${ETCD_LOG_PATH}/endpoint_health.json
+ocp4etcdctl endpoint health -w table > ${ETCD_LOG_PATH}/endpoint_health.txt &
+PIDS+=($!)
+ocp4etcdctl endpoint health -w json > ${ETCD_LOG_PATH}/endpoint_health.json &
+PIDS+=($!)
 
 # alarm list
 echo "INFO: Getting etcdctl alarm list"
-ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt
-ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json
+ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt &
+PIDS+=($!)
+ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json &
+PIDS+=($!)
 
-echo "INFO: Done gathering etcd information"
+echo "INFO: Waiting for etcd info collection to complete ..."
+wait ${PIDS[@]}
+echo "INFO: Done collecting etcd information"

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -3,16 +3,20 @@
 BASE_COLLECTION_PATH="/must-gather"
 ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
 
+ETCD_CONTAINER='etcdctl'
+
 RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
 
 function ocp4etcdctl {
-    oc -n openshift-etcd exec -c etcdctl ${RUNNING_ETCD_POD} -- etcdctl $@
+    oc -n openshift-etcd exec -c ${ETCD_CONTAINER} ${RUNNING_ETCD_POD} -- etcdctl $@
 }
 
 if [[ -z $RUNNING_ETCD_POD ]];then
     echo "ERROR: No running etcd pods found" >&2
     exit 1
 fi
+
+echo "Getting information from pod \"${RUNNING_ETCD_POD}\", container \"${ETCD_CONTAINER}\""
 
 mkdir -p ${ETCD_LOG_PATH}
 

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="/must-gather"
+ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
+
+RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
+
+function ocp4etcdctl {
+    oc -n openshift-etcd exec -c etcdctl ${RUNNING_ETCD_POD} -- etcdctl $@
+}
+
+if [[ -z $RUNNING_ETCD_POD ]];then
+    echo "ERROR: No running etcd pods found" >&2
+    exit 1
+fi
+
+mkdir -p ${ETCD_LOG_PATH}
+
+echo "INFO: Starting getting etcd information"
+
+# member list
+echo "INFO: Getting etcdctl member list"
+ocp4etcdctl member list -w table > ${ETCD_LOG_PATH}/member_list.txt
+ocp4etcdctl member list -w json > ${ETCD_LOG_PATH}/member_list.json
+
+# endpoint status
+echo "INFO: Getting etcdctl endpoint status"
+ocp4etcdctl endpoint status -w table > ${ETCD_LOG_PATH}/endpoint_status.txt
+ocp4etcdctl endpoint status -w json > ${ETCD_LOG_PATH}/endpoint_status.json
+
+# endpoint health
+echo "INFO: Getting etcdctl endpoint health"
+ocp4etcdctl endpoint health -w table > ${ETCD_LOG_PATH}/endpoint_health.txt
+ocp4etcdctl endpoint health -w json > ${ETCD_LOG_PATH}/endpoint_health.json
+
+# alarm list
+echo "INFO: Getting etcdctl alarm list"
+ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt
+ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json
+
+# List all etcd keys
+echo "INFO: Getting list of keys in etcd"
+ocp4etcdctl get --keys-only --from-key / > ${ETCD_LOG_PATH}/etcd_keys.txt
+
+# Check perf
+echo "INFO: Performing etcdctl check perf"
+ocp4etcdctl check perf --load="s" > ${ETCD_LOG_PATH}/etcd_check_perf.txt
+
+echo "INFO: Done gathering etcd information"

--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -46,8 +46,4 @@ echo "INFO: Getting etcdctl alarm list"
 ocp4etcdctl alarm list > ${ETCD_LOG_PATH}/alarm_list.txt
 ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json
 
-# Check perf
-echo "INFO: Performing etcdctl check perf"
-ocp4etcdctl check perf --load="s" > ${ETCD_LOG_PATH}/etcd_check_perf.txt
-
 echo "INFO: Done gathering etcd information"


### PR DESCRIPTION
One of the most important things to check while getting information from a cluster is to check the cluster etcd health. This cannot be achieved by just getting some pod logs or kubernetes resources, but needs its own set of commands to be run in etcd pods.

In this pull request, I am adding a `gather_etcd` script to gather that information and I also made it to be run by default from main `gather` script.

Having this information on every must-gather would be of great help for support.

I'll be happy to help with any change or improvement required on this. And thanks in advance.