### PR TITLE
collection-scripts/gather: drop MCO resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -18,7 +18,7 @@ resources+=(clusteroperators)
 resources+=(certificatesigningrequests)
 
 # Machine/Node Resources
-resources+=(nodes machineconfigs machineconfigpools)
+resources+=(nodes)
 
 # Namespaces/Project Resources
 resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)


### PR DESCRIPTION
The MCO relatedObjects field grabs those

Signed-off-by: Antonio Murdaca <runcom@linux.com>