### PR TITLE
gather_service_logs: Gather MCO host services

### DIFF
--- a/collection-scripts/gather_service_logs
+++ b/collection-scripts/gather_service_logs
@@ -2,8 +2,8 @@
 BASE_COLLECTION_PATH="/must-gather"
 ROLES=${1:-master}         ### Defaults to only collecting things from Masters
 
-# Service Lists
-GENERAL_SERVICES=(kubelet crio)
+# Service Lists; see also https://github.com/openshift/machine-config-operator/issues/1365
+GENERAL_SERVICES=(kubelet crio machine-config-daemon-firstboot machine-config-daemon-host)
 MASTER_SERVICES+=${2:-${GENERAL_SERVICES[@]}}
 MASTER_SERVICES+=()        ### Placeholder to extend Master only services
 NODE_SERVICES+=${2:-${GENERAL_SERVICES[@]}}


### PR DESCRIPTION
Motivated by https://bugzilla.redhat.com/show_bug.cgi?id=1842906
and many prior bugs.  Also added a link to
https://github.com/openshift/machine-config-operator/issues/1365
which I think would be a better fix for early cluster bringup.

Also xref https://github.com/openshift/machine-config-operator/pull/1790