### PR TITLE
Add CSI storage objects

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -24,7 +24,7 @@ resources+=(nodes)
 resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)
 
 # Storage Resources
-resources+=(storageclasses persistentvolumes volumeattachments)
+resources+=(storageclasses persistentvolumes volumeattachments csidrivers)
 
 # Image-source Resources
 resources+=(imagecontentsourcepolicies.operator.openshift.io)


### PR DESCRIPTION
must-gather should collect these Kubernetes objects too:

* CSIDriver - information about installed CSI drivers (one per driver, usually few per cluster)
~* CSINode - information about CSI driver topology (one per node)~