### PR TITLE
collects audit logs for oauth-apiserver

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -35,3 +35,4 @@ function collect_audit_logs {  ### Takes an input of PATH
 
 collect_audit_logs openshift-apiserver
 collect_audit_logs kube-apiserver
+collect_audit_logs oauth-apiserver


### PR DESCRIPTION
this PR will collect the audit logs for a new API server introduced in https://github.com/openshift/cluster-authentication-operator/pull/243

I set up a cluster with the new API server and did

```
oc adm node-logs --role=master --path=oauth-apiserver
ip-10-0-143-47.us-east-2.compute.internal audit.log
ip-10-0-166-233.us-east-2.compute.internal audit.log
ip-10-0-200-62.us-east-2.compute.internal audit.log
```