### PR TITLE
Separate Linux and Windows node log collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -46,3 +46,6 @@ done
 
 # Gather Service Logs (using a suplamental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
+
+# Gather Windows Kubernetes component logs
+/usr/bin/gather_windows_node_logs

--- a/collection-scripts/gather_network_ovn_trace
+++ b/collection-scripts/gather_network_ovn_trace
@@ -108,7 +108,7 @@ function gather_service_data {
     > ${NETWORK_TRACE_PATH}/master_crio.log &
   PIDS+=($!)
 
-  oc adm node-logs --role="worker" -u crio | \
+  oc adm node-logs --role="worker" -l kubernetes.io/os=linux -u crio | \
     convert_journal_timestamp \
     > ${NETWORK_TRACE_PATH}/worker_crio.log &
   PIDS+=($!)
@@ -119,7 +119,7 @@ function gather_service_data {
     > ${NETWORK_TRACE_PATH}/master_kubelet.log &
   PIDS+=($!)
 
-  oc adm node-logs --role="worker" -u kubelet | \
+  oc adm node-logs --role="worker" -l kubernetes.io/os=linux -u kubelet | \
     grep -e "SyncLoop" -e "\]: E" | \
     convert_journal_timestamp \
     > ${NETWORK_TRACE_PATH}/worker_kubelet.log &

--- a/collection-scripts/gather_service_logs
+++ b/collection-scripts/gather_service_logs
@@ -15,11 +15,11 @@ SERVICE_LOG_PATH="${BASE_COLLECTION_PATH}/host_service_logs/"
 function collect_serivce_logs {  ## Takes a node role input (master or worker)
     PIDS=()
     DIR_PATH=${SERVICE_LOG_PATH}/${1}s
-    echo "WARNING: Collecting one or more service logs on ALL $1 nodes in your cluster. This could take a large amount of time." >&2
+    echo "WARNING: Collecting one or more service logs on ALL linux $1 nodes in your cluster. This could take a large amount of time." >&2
     mkdir -p ${DIR_PATH}
     for service in ${NODE_SERVICES[@]}; do
         echo "INFO: Collecting host service logs for $service"
-        /usr/bin/oc adm node-logs --role=$1 -u $service > ${DIR_PATH}/${service}_service.log &
+        /usr/bin/oc adm node-logs --role=$1 -l kubernetes.io/os=linux -u $service > ${DIR_PATH}/${service}_service.log &
 	PIDS+=($!)
     done
     echo "INFO: Waiting for worker host service log collection to complete ..."

--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -1,0 +1,22 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="/must-gather"
+WINDOWS_NODE_LOGS=$BASE_COLLECTION_PATH/host_service_logs/windows
+
+# Logfile list
+LOGS=(kube-proxy/kube-proxy.exe.INFO kube-proxy/kube-proxy.exe.ERROR kube-proxy/kube-proxy.exe.WARNING)
+LOGS+=(hybrid-overlay/hybrid-overlay.log kubelet/kubelet.log)
+
+# if the cluster has no Windows nodes skip this script
+WIN_NODES=$(/usr/bin/oc get no -l kubernetes.io/os=windows)
+if [ -z "$WIN_NODES" ]; then
+    exit 0
+fi
+
+echo INFO: Collecting logs for all Windows nodes
+for log in ${LOGS[@]}; do
+    LOG_DIR=${WINDOWS_NODE_LOGS}/$(dirname $log)
+    mkdir -p ${LOG_DIR}
+    /usr/bin/oc adm node-logs -l kubernetes.io/os=windows --path=$log > ${LOG_DIR}/$(basename $log) &
+    PIDS+=($!)
+done
+wait ${PIDS[@]}


### PR DESCRIPTION
The '-u' flag for 'oc adm node-logs' cannot be used against Windows
nodes. This commit ensures that the '-u' method of collection is only
used for services running on Linux nodes, and the '--path' option is
used for collecting Windows node log files.