### PR TITLE
Gather more storage objects

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -24,7 +24,7 @@ resources+=(nodes)
 resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)
 
 # Storage Resources
-resources+=(storageclasses persistentvolumes volumeattachments csidrivers)
+resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)
 
 # Image-source Resources
 resources+=(imagecontentsourcepolicies.operator.openshift.io)


### PR DESCRIPTION
VolumeSnapshotClasses, VolumeSnapshotContents and CSINodes are Kubernetes objects not related to any OCP operator.

CSINodes have OwnerReference to Nodes, however, `oc must-gather` does not track owners, see https://bugzilla.redhat.com/show_bug.cgi?id=1861650.

These objects are available on OCP 4.4 and newer.

/assign @sferich888 