### PR TITLE
Bug 1868716: Implements more log collection for Openshift networking

### DIFF
--- a/collection-scripts/gather_core_dumps
+++ b/collection-scripts/gather_core_dumps
@@ -1,0 +1,24 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+CORE_DUMP_PATH=${OUT:-"${BASE_COLLECTION_PATH}/node_core_dumps"}
+
+mkdir -p ${CORE_DUMP_PATH}/
+
+function gather_core_dump_data {
+  for NODE in ${NODES}; do
+    oc debug node/${NODE} -- chroot /host /bin/bash -c "coredumpctl info" > ${CORE_DUMP_PATH}/${NODE}_core_dump & PIDS+=($!)
+  done
+}
+
+if [ $# -eq 0 ]; then
+    echo "WARNING: Collecting network logs on ALL linux nodes in your cluster. This could take a long time." >&2
+fi
+
+PIDS=()
+NODES="${@:-$(oc get nodes -o jsonpath='{range .items[*]}{@.metadata.name} {.status.nodeInfo.operatingSystem==linux}')}"
+
+gather_core_dump_data
+
+echo "INFO: Waiting for node core dump collection to complete ..."
+wait ${PIDS[@]}
+echo "INFO: Node core dump collection to complete."

--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -56,6 +56,13 @@ function gather_ovn_kubernetes_nodes_data {
       oc -n openshift-ovn-kubernetes exec ${OVS_NODE_POD} -- bash -c \
       "ovs-ofctl dump-flows br-local" > ${NETWORK_LOG_PATH}/${NODE}_${OVS_NODE_POD}_ovs_ofctl_dump_flows_br_local &
       PIDS+=($!)
+       oc -n openshift-ovn-kubernetes exec ${OVS_NODE_POD} -- bash -c \
+      "ovs-ofctl dump-ports-desc br-ex" > ${NETWORK_LOG_PATH}/${NODE}_${OVS_NODE_POD}_ovs_ofctl_dump_ports_br_ex &
+      PIDS+=($!)
+      oc -n openshift-ovn-kubernetes exec ${OVS_NODE_POD} -- bash -c \
+      "ovs-ofctl dump-flows br-ex" > ${NETWORK_LOG_PATH}/${NODE}_${OVS_NODE_POD}_ovs_ofctl_dump_flows_br_ex &
+      PIDS+=($!)
+
       oc -n openshift-ovn-kubernetes exec ${OVS_NODE_POD} -- bash -c \
       "ovs-vsctl show" > ${NETWORK_LOG_PATH}/${NODE}_${OVS_NODE_POD}_ovs_dump &
       PIDS+=($!)
@@ -65,11 +72,13 @@ function gather_ovn_kubernetes_nodes_data {
 
       if [[ ${OVNKUBE_MASTER} != "" ]] ; then
         oc cp openshift-ovn-kubernetes/${OVNKUBE_MASTER}:/etc/openvswitch/ovnsb_db.db ${NETWORK_LOG_PATH}/${NODE}_ovnsb_db.db > ${NETWORK_LOG_PATH}/${NODE}_sbdb &
+        gzip ${NETWORK_LOG_PATH}/${NODE}_sbdb &        
         PIDS+=($!)
+        
         oc cp openshift-ovn-kubernetes/${OVNKUBE_MASTER}:/etc/openvswitch/ovnnb_db.db ${NETWORK_LOG_PATH}/${NODE}_ovnnb_db.db > ${NETWORK_LOG_PATH}/${NODE}_nbdb &
+        gzip ${NETWORK_LOG_PATH}/${NODE}_nbdb &
         PIDS+=($!)
       fi
-
   done
 }
 
@@ -123,11 +132,11 @@ function gather_kuryr_data {
 
 
 if [ $# -eq 0 ]; then
-    echo "WARNING: Collecting network logs on ALL nodes in your cluster. This could take a long time." >&2
+    echo "WARNING: Collecting network logs on ALL linux nodes in your cluster. This could take a long time." >&2
 fi
 
 PIDS=()
-NODES="${@:-$(oc get nodes --no-headers -o custom-columns=':metadata.name')}"
+NODES="${@:-$(oc get nodes -o jsonpath='{range .items[*]}{@.metadata.name} {.status.nodeInfo.operatingSystem==linux}')}"
 NETWORK_TYPE=$(oc get network.config.openshift.io -o=jsonpath='{.items[0].spec.networkType}' | tr '[:upper:]' '[:lower:]')
 if [[ "${NETWORK_TYPE}" == "openshiftsdn" ]]; then
     gather_openshiftsdn_nodes_data


### PR DESCRIPTION
This PR implements more log collection for Openshift Networking,

with OVN-Kubernetes

-It fixes https://bugzilla.redhat.com/show_bug.cgi?id=1868716

-Specifically it adds the collection script `gather_core_dumps`
to collect core dumps on hosts

-Zips the ovn-nb/sb.db files and adds flow/port
dumping for the br-ex interface in `gather_network_logs`

-Ensures for both `gather_network_logs` and `gather_core_dumps`
that we only query linux based nodes

-Leaves the networking logging off by default in `gather`

-to run the networking collection scripts use the following
command:
`oc adm must-gather -- gather && gather_core_dumps &&
gather_network_logs && gather_network_ovn_trace`

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>