### PR TITLE
gather_network_logs: specfiy sdn container for sdn pods

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -7,9 +7,9 @@ mkdir -p ${NETWORK_LOG_PATH}/
 function gather_openshiftsdn_nodes_data {
   for NODE in ${NODES}; do
       SDN_POD=$(oc -n openshift-sdn get pods --no-headers -o custom-columns=":metadata.name" --field-selector spec.nodeName=${NODE} -l app=sdn)
-      oc -n openshift-sdn exec ${SDN_POD} -- bash -c "iptables-save -c" > ${NETWORK_LOG_PATH}/${NODE}_iptables &
+      oc -n openshift-sdn exec ${SDN_POD} -c sdn -- bash -c "iptables-save -c" > ${NETWORK_LOG_PATH}/${NODE}_iptables &
       PIDS+=($!)
-      oc -n openshift-sdn exec ${SDN_POD} -- bash -c "ovs-vsctl show" > ${NETWORK_LOG_PATH}/${NODE}_ovs_dump &
+      oc -n openshift-sdn exec ${SDN_POD} -c sdn -- bash -c "ovs-vsctl show" > ${NETWORK_LOG_PATH}/${NODE}_ovs_dump &
       PIDS+=($!)
 
       OVS_POD=$(oc -n openshift-sdn get pods --no-headers -o custom-columns=":metadata.name" --field-selector spec.nodeName=${NODE} -l app=ovs)


### PR DESCRIPTION
`app=sdn` pods added a `kube-rbac-proxy` container so we
should now specify the `sdn` container explicitly when
execing in the sdn pods.

Thin prevents the warnings:
```
[must-gather-dbslg] POD Defaulting container name to sdn.
[must-gather-dbslg] POD Use 'oc describe pod/sdn-ljds8 -n openshift-sdn' to see all of the containers in this pod.
```