### PR TITLE
Bug 1862643: Collect docker logs from WinEvent log on Windows machines

### DIFF
--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -2,6 +2,9 @@
 BASE_COLLECTION_PATH="/must-gather"
 WINDOWS_NODE_LOGS=$BASE_COLLECTION_PATH/host_service_logs/windows
 
+# Services logging to WinEvent log
+SERVICES=(docker)
+
 # Logfile list
 LOGS=(kube-proxy/kube-proxy.exe.INFO kube-proxy/kube-proxy.exe.ERROR kube-proxy/kube-proxy.exe.WARNING)
 LOGS+=(hybrid-overlay/hybrid-overlay.log kubelet/kubelet.log)
@@ -12,11 +15,19 @@ if [ -z "$WIN_NODES" ]; then
     exit 0
 fi
 
+PIDS=()
+LOG_WINEVENT_DIR=${WINDOWS_NODE_LOGS}/log_winevent/
+mkdir -p ${LOG_WINEVENT_DIR}
 echo INFO: Collecting logs for all Windows nodes
+for service in ${SERVICES[@]}; do
+    echo "INFO: Collecting WinEvent application logs for provider $service"
+    /usr/bin/oc adm node-logs -l kubernetes.io/os=windows -u $service > ${LOG_WINEVENT_DIR}/${service}_winevent.log &
+    PIDS+=($!)
+done
 for log in ${LOGS[@]}; do
-    LOG_DIR=${WINDOWS_NODE_LOGS}/$(dirname $log)
-    mkdir -p ${LOG_DIR}
-    /usr/bin/oc adm node-logs -l kubernetes.io/os=windows --path=$log > ${LOG_DIR}/$(basename $log) &
+    LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname $log)
+    mkdir -p ${LOG_FILE_DIR}
+    /usr/bin/oc adm node-logs -l kubernetes.io/os=windows --path=$log > ${LOG_FILE_DIR}/$(basename $log) &
     PIDS+=($!)
 done
 wait ${PIDS[@]}


### PR DESCRIPTION
Use the Get-WinEvent shim on kubelet logs endpoint introduced in
https://github.com/openshift/kubernetes/pull/383 to collect docker
runtime logs from Windows machines.

/cc @sebsoto @aravindhp 
/cherry-pick release-4.6