### PR TITLE
Bug 1906968: Add kubernetes-nmstate resources to must-gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -36,6 +36,9 @@ group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)
 
+# NodeNetworkState
+resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
+
 # Run the Collection of Resources using inspect
 # running accross all-namespaces for the few "Autoscaler" resouces.
 oc adm inspect --dest-dir must-gather "${named_resources[@]}"


### PR DESCRIPTION
If kubernetes-nmstate is on a cluster, these resources would be helpful
to ascertain what possible network configurations on present on nodes.