### PR TITLE
remove duplicate collection of admissionwebhooks

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -54,10 +54,6 @@ oc adm inspect --dest-dir must-gather "${group_resources_text}"
 # Gather etcd information
 /usr/bin/gather_etcd
 
-# Gather Validation and Mutating Admission Webhook Objects
-# TODO the kube-apiserver operator should list these as related resources
-/usr/bin/gather_admission_webhooks
-
 # Gather Service Logs (using a supplemental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
 

--- a/collection-scripts/gather_admission_webhooks
+++ b/collection-scripts/gather_admission_webhooks
@@ -1,7 +1,0 @@
-#!/bin/bash
-BASE_COLLECTION_PATH="/must-gather"
-WEB_HOOK_PATH="${BASE_COLLECTION_PATH}/web_hooks/"
-
-mkdir -p ${WEB_HOOK_PATH}
-oc get mutatingwebhookconfigurations -o yaml > ${WEB_HOOK_PATH}/mutatingwebhookconfigurations.yaml
-oc get validatingwebhookconfigurations -o yaml > ${WEB_HOOK_PATH}/validatingwebhookconfigurations.yaml


### PR DESCRIPTION
this appears to already be collected in https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/starter.go#L217-L218 and https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml#L40-L43

/hold 

holding so we can look at artifacts and make sure we get the data we expect.