### PR TITLE
Collect configuration and events for vsphere clusters

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -63,5 +63,8 @@ oc adm inspect --dest-dir must-gather "${group_resources_text}"
 # Gather HAProxy config files
 /usr/bin/gather_haproxy_config
 
+# Gather vSphere Config and Events
+/usr/bin/gather_vsphere_config
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_vsphere_config
+++ b/collection-scripts/gather_vsphere_config
@@ -1,0 +1,16 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+VSPHERE_CONFIG_EVENTS_PATH=$BASE_COLLECTION_PATH/vsphere_config_events
+
+if [ -z "$(oc get deployment -n openshift-cluster-storage-operator vsphere-problem-detector-operator | grep vsphere-problem-detector-operator)" ]; then
+exit
+fi
+
+METRICS="vsphere_vcenter_info vsphere_features vsphere_cluster_check_total vsphere_cluster_check_errors vsphere_node_check_errors vsphere_node_check_total vsphere_node_hw_version_total"
+mkdir -p $VSPHERE_CONFIG_EVENTS_PATH
+for METRIC in $METRICS; do
+/usr/bin/oc exec -c prometheus -n openshift-monitoring prometheus-k8s-0 -- curl -s --data-urlencode "query=$METRIC" http://localhost:9090/api/v1/query > $VSPHERE_CONFIG_EVENTS_PATH/$METRIC.json
+done
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
vSphere events and configuration which are helpful to understanding the state of the environment housing the cluster are stored in prometheus and fed from the vsphere-problem-detector.  This pull-request adds a script which, when run on a vSphere cluster, retrieves and stores the gathered information.