### PR TITLE
Add non-baremetal on-prem platform namespaces

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -25,7 +25,7 @@ group_resources+=(certificatesigningrequests)
 group_resources+=(nodes)
 
 # Namespaces/Project Resources
-named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)
+named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra ns/openshift-openstack-infra ns/openshift-vsphere-infra ns/openshift-ovirt-infra)
 
 # Storage Resources
 group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)


### PR DESCRIPTION
Initially only the baremetal (kni) namespace was included in the
must-gather contents. Unfortunately, different namespaces were used
for all of the on-prem platforms so this misses the non-baremetal
ones. This change adds adds the other on-prem platforms so we will
have the necessary logs from those platforms as well.