### PR TITLE
Bug 1916809: extend must-gather network log to include nodes' ovs DB

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -66,6 +66,32 @@ function gather_openshiftsdn_nodes_data {
   done
 }
 
+function get_ovsdb_off_node {
+    local debugPod=""
+
+    #Get debug pod's name
+    debugPod=$(oc debug --to-namespace="default" node/"$1" -o jsonpath='{.metadata.name}')
+
+    #Start Debug pod force it to stay up until removed in "default" namespace
+    oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' > /dev/null 2>&1 &
+
+    #Mimic a normal oc call, i.e pause between two successive calls to allow pod to register
+    sleep 2
+    oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s
+
+    if [ -z "$debugPod" ]
+    then
+      echo "Debug pod for node ""$1"" never activated"
+    else
+      #Copy Core Dumps out of Nodes suppress Stdout
+      echo "Copying ovsdb on node ""$1"""
+      oc cp  --loglevel 1 -n "default" "$debugPod":/host/etc/openvswitch/conf.db "${NETWORK_LOG_PATH}"/"$1"_conf.db > /dev/null 2>&1 && PIDS+=($!)
+
+      #clean up debug pod after we are done using them
+      oc delete pod "$debugPod" -n "default"
+    fi
+}
+
 function gather_ovn_kubernetes_nodes_data {
   echo "INFO: Gathering ovn-kubernetes node data"
   for NODE in ${NODES}; do
@@ -104,6 +130,8 @@ function gather_ovn_kubernetes_nodes_data {
       oc -n openshift-ovn-kubernetes exec -c ovnkube-node "${OVNKUBE_NODE_POD}" -- bash -c \
       "ovs-vsctl show" > "${NETWORK_LOG_PATH}"/"${NODE}"_ovs_dump &
       PIDS+=($!)
+
+      get_ovsdb_off_node "${NODE}" &
 
       oc -n openshift-ovn-kubernetes exec -c ovnkube-node "${OVNKUBE_NODE_POD}" -- bash -c \
       "ethtool -i $(ip route show default | cut -d ' ' -f5)" > "${NETWORK_LOG_PATH}"/"${NODE}"_ethtool_driver &

--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -105,8 +105,8 @@ function gather_ovn_kubernetes_nodes_data {
       "ovs-vsctl show" > "${NETWORK_LOG_PATH}"/"${NODE}"_ovs_dump &
       PIDS+=($!)
 
-     oc cp openshift-ovn-kubernetes/"${OVNKUBE_NODE_POD}":/etc/openvswitch/conf.db -c ovnkube-node \
-    "${NETWORK_LOG_PATH}"/"${OVNKUBE_NODE_POD}"_conf.db 2>&1
+      oc cp openshift-ovn-kubernetes/"${OVNKUBE_NODE_POD}":/etc/openvswitch/conf.db -c ovnkube-node \
+      "${NETWORK_LOG_PATH}"/"${OVNKUBE_NODE_POD}"_conf.db 2>&1
 
       oc -n openshift-ovn-kubernetes exec -c ovnkube-node "${OVNKUBE_NODE_POD}" -- bash -c \
       "ethtool -i $(ip route show default | cut -d ' ' -f5)" > "${NETWORK_LOG_PATH}"/"${NODE}"_ethtool_driver &

--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -66,32 +66,6 @@ function gather_openshiftsdn_nodes_data {
   done
 }
 
-function get_ovsdb_off_node {
-    local debugPod=""
-
-    #Get debug pod's name
-    debugPod=$(oc debug --to-namespace="default" node/"$1" -o jsonpath='{.metadata.name}')
-
-    #Start Debug pod force it to stay up until removed in "default" namespace
-    oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' > /dev/null 2>&1 &
-
-    #Mimic a normal oc call, i.e pause between two successive calls to allow pod to register
-    sleep 2
-    oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s
-
-    if [ -z "$debugPod" ]
-    then
-      echo "Debug pod for node ""$1"" never activated"
-    else
-      #Copy Core Dumps out of Nodes suppress Stdout
-      echo "Copying ovsdb on node ""$1"""
-      oc cp  --loglevel 1 -n "default" "$debugPod":/host/etc/openvswitch/conf.db "${NETWORK_LOG_PATH}"/"$1"_conf.db > /dev/null 2>&1 && PIDS+=($!)
-
-      #clean up debug pod after we are done using them
-      oc delete pod "$debugPod" -n "default"
-    fi
-}
-
 function gather_ovn_kubernetes_nodes_data {
   echo "INFO: Gathering ovn-kubernetes node data"
   for NODE in ${NODES}; do
@@ -131,7 +105,8 @@ function gather_ovn_kubernetes_nodes_data {
       "ovs-vsctl show" > "${NETWORK_LOG_PATH}"/"${NODE}"_ovs_dump &
       PIDS+=($!)
 
-      get_ovsdb_off_node "${NODE}" &
+     oc cp openshift-ovn-kubernetes/"${OVNKUBE_NODE_POD}":/etc/openvswitch/conf.db -c ovnkube-node \
+    "${NETWORK_LOG_PATH}"/"${OVNKUBE_NODE_POD}"_conf.db 2>&1
 
       oc -n openshift-ovn-kubernetes exec -c ovnkube-node "${OVNKUBE_NODE_POD}" -- bash -c \
       "ethtool -i $(ip route show default | cut -d ' ' -f5)" > "${NETWORK_LOG_PATH}"/"${NODE}"_ethtool_driver &


### PR DESCRIPTION
Description
extending must gather network logging to include ovs db dump to enhance debugging.

Type of change
Enhance debugging of openshift cluster.

How Has This Been Tested?
created Openshift cluster ob GCP
run must gather using my special image from qauy
```
oc adm must-gather --image=quay.io/mmahmoud/must-gather-test:1.1 gather_network_logs
```
check conf.db files is gathered for all nodes
/home/mmahmoud/data/must-gather.local.5971192883354181951/quay-io-mmahmoud-must-gather-test-sha256-0cc86c9604173fe30cde33abcdcd0b71eebd9701a94b0635464edb61ed5d01e9/network_logs
[mmahmoud@mmahmoud network_logs]$ ls -l *conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 887425 Mar 24 07:44 ovnkube-node-7ntlv_conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 166369 Mar 24 07:44 ovnkube-node-gwzqh_conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 681968 Mar 24 07:44 ovnkube-node-jdzwm_conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 191094 Mar 24 07:44 ovnkube-node-kgsj8_conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 690742 Mar 24 07:44 ovnkube-node-mj7wm_conf.db
-rw-r--r--. 1 mmahmoud mmahmoud 527500 Mar 24 07:44 ovnkube-node-w9kjm_conf.db

[mmahmoud@mmahmoud images]$ oc get pods | grep "ovnkube-node"
ovnkube-node-7ntlv     3/3     Running   1          12m
ovnkube-node-gwzqh     3/3     Running   1          13m
ovnkube-node-jdzwm     3/3     Running   1          13m
ovnkube-node-kgsj8     3/3     Running   1          13m
ovnkube-node-mj7wm     3/3     Running   1          13m
ovnkube-node-w9kjm     3/3     Running   1          13m
