### PR TITLE
Bug 1958094: gather_audit_logs: ignore .lock file

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -16,6 +16,7 @@ for path in "${paths[@]}" ; do
   oc adm node-logs --role=master --path="$path" | \
   tee "${BASE_COLLECTION_PATH}/audit_logs/$path.audit_logs_listing" | \
   grep -v ".terminating" | \
+  grep -v ".lock" | \
   sed "s|^|$path $output_dir |"
 done | \
 xargs --max-args=4 --max-procs=45 bash -c \


### PR DESCRIPTION
Skip .lock file from https://github.com/openshift/cluster-kube-apiserver-operator/pull/1128.