### PR TITLE
Bug 1953563: Add .ci-operator.yaml with build_root_image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.12


### PR DESCRIPTION
Preparation for https://github.com/openshift/must-gather/pull/228.