### PR TITLE
Bug 1958405: add etcd health logs to audit

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -9,7 +9,7 @@ echo "WARNING: Collecting one or more audit logs on ALL masters in your cluster.
 # $2 - local output path
 # $3 - node name
 # $4 - log file name
-paths=(openshift-apiserver kube-apiserver oauth-apiserver)
+paths=(openshift-apiserver kube-apiserver oauth-apiserver etcd)
 for path in "${paths[@]}" ; do
   output_dir="${BASE_COLLECTION_PATH}/audit_logs/$path"
   mkdir -p "$output_dir"


### PR DESCRIPTION
https://github.com/openshift/cluster-etcd-operator/pull/596 adds health audit logs for etcd. This PR adds those logs to the audit_logs gather script. This script is already known by support and users and the etcd state should not be large in size. Piggybacking the logs along with the other control-plane components seems logical.

alternative : https://github.com/openshift/must-gather/pull/236