### PR TITLE
add health audit log collection for etcd

### DIFF
--- a/collection-scripts/gather_health_audit_logs
+++ b/collection-scripts/gather_health_audit_logs
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Downloads the health audit log (and its rotated copies) from
+# /var/logs/etcd on each master node.
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+echo "WARNING: Collecting one or more health audit logs on ALL masters in your cluster. This could take a large amount of time." >&2
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+path=etcd
+output_dir="${BASE_COLLECTION_PATH}/health_audit_logs/$path"
+mkdir -p "$output_dir"
+oc adm node-logs --role=master --path=$path | \
+tee "${BASE_COLLECTION_PATH}/health_audit_logs/$path.health_audit_logs_listing" | \
+sed "s|^|$path $output_dir |" | \
+xargs --max-args=4 --max-procs=45 bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+echo "INFO: health audit logs collected."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
This PR is an alternative to #235 and introduces the health audit log to must gather. The naming this generic in case we decide to extend the pattern to other components.

/hold