### PR TITLE
Remove openshift-kni-infra namespace from gather script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -25,7 +25,7 @@ group_resources+=(certificatesigningrequests)
 group_resources+=(nodes)
 
 # Namespaces/Project Resources
-named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd ns/openshift-kni-infra)
+named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
 
 # Storage Resources
 group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)


### PR DESCRIPTION
This namespace is now handled properly by relatedObjects in MCO, so
we no longer need to have it listed explicitly here.