### PR TITLE
Collecting the output of `oc adm top resource`

### DIFF
--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -25,5 +25,17 @@ oc get\
 
 rm "${MONITORING_PATH}/ca-bundle.crt"
 
+function get_top {
+    
+    echo "INFO: Collecting 'oc adm top nodes'"
+    oc adm top nodes --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-nodes.out"
+
+    echo "INFO: Collecting 'oc adm top pods'"
+    oc adm top pods --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-pods.out"
+
+}
+
+get_adm_top
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -21,26 +21,41 @@ oc get\
   --server="https://${MONITORING_ROUTE}"\
   --token="${SA_TOKEN}" \
   --certificate-authority="${MONITORING_PATH}/ca-bundle.crt" \
-  --raw=/api/v1/rules?type=alert 2>"${MONITORING_PATH}/alert.stderr" > "${MONITORING_PATH}/alerts.json"
+  --raw=/api/v1/rules?type=alert \
+  2>"${MONITORING_PATH}/alert.stderr" \
+  > "${MONITORING_PATH}/alerts.json" || true
 
 rm "${MONITORING_PATH}/ca-bundle.crt"
 
 function get_top_nodes {
-    oc adm top nodes --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-nodes.out"
+    oc adm top node &> "${MONITORING_PATH}/adm-top-nodes.out"
 }
 
 function get_top_pods {
-    oc adm top pods --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-pods.out"
+    oc adm top pod -A &> "${MONITORING_PATH}/adm-top-pods.out"
+}
+
+function get_top_images {
+    oc adm top images &> "${MONITORING_PATH}/adm-top-images.out"
+}
+
+function get_top_is {
+    oc adm top imagestreams &> "${MONITORING_PATH}/adm-top-imagestreams.out"
 }
 
 function get_top {
     
-    echo "INFO: Collecting 'oc adm top nodes'"
+    echo "INFO: Collecting 'oc adm top node'"
     get_top_nodes || true
 
-    echo "INFO: Collecting 'oc adm top pods'"
+    echo "INFO: Collecting 'oc adm top pod'"
     get_top_pods || true
 
+    echo "INFO: Collecting 'oc adm top images'"
+    get_top_images || true
+
+    echo "INFO: Collecting 'oc adm top imagestreams'"
+    get_top_is || true
 }
 
 get_top

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -25,13 +25,21 @@ oc get\
 
 rm "${MONITORING_PATH}/ca-bundle.crt"
 
+function get_top_nodes {
+    oc adm top nodes --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-nodes.out"
+}
+
+function get_top_pods {
+    oc adm top pods --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-pods.out"
+}
+
 function get_top {
     
     echo "INFO: Collecting 'oc adm top nodes'"
-    oc adm top nodes --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-nodes.out"
+    get_top_nodes || true
 
     echo "INFO: Collecting 'oc adm top pods'"
-    oc adm top pods --sort-by='cpu' &> "${MONITORING_PATH}/adm-top-pods.out"
+    get_top_pods || true
 
 }
 

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -43,7 +43,7 @@ function get_top {
 
 }
 
-get_adm_top
+get_top
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync


### PR DESCRIPTION
Collecting the output of `oc adm top RESOURCE` to avoid request extra info to user.

- exec times
~~~
[...]
[must-gather-gg5t4] POD 2021-06-15T04:48:01.819720152Z INFO: Collecting 'oc adm top node'
[must-gather-gg5t4] POD 2021-06-15T04:48:02.034506208Z INFO: Collecting 'oc adm top pod'
[must-gather-gg5t4] POD 2021-06-15T04:48:02.549873182Z INFO: Collecting 'oc adm top images'
[must-gather-gg5t4] POD 2021-06-15T04:48:03.390303363Z INFO: Collecting 'oc adm top imagestreams'
[...]
~~~

- data sizes
~~~
-rw-r--r--. 1 u g 103K Jun 15 00:48 adm-top-images.out
-rw-r--r--. 1 u g 7.8K Jun 15 00:48 adm-top-imagestreams.out
-rw-r--r--. 1 u g  714 Jun 15 00:48 adm-top-nodes.out
-rw-r--r--. 1 u g  26K Jun 15 00:48 adm-top-pods.out
~~~