### PR TITLE
Bug 1974364: Change the way of gathering ovn db

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -169,32 +169,19 @@ function gather_ovn_kubernetes_master_data {
   PIDS+=($!)
 
   for OVNKUBE_MASTER_POD in ${OVNKUBE_MASTER_PODS[@]}; do
-    #get nbdb and sbdb sizes before and after db compaction, run serially to ensure event timeline 
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}"  -c nbdb -- ls -lht /etc/ovn/ \
-    > "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb_size_pre_compact
+    # ovsdb-client backup output does not include ephemeral columns, which by design
+    # do not survive across restarts of ovsdb-server.
+    # The database snapshot that it outputs is suitable to be served up directly by
+    # ovsdb-server or used as the input to ovsdb-client restore.
+    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c nbdb -- ovsdb-client backup unix:/var/run/ovn/ovnnb_db.sock > \
+    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb
 
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}"  -c sbdb -- ls -lht /etc/ovn/ \
-    > "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb_size_pre_compact
- 
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c sbdb -- ovs-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact 
+    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c sbdb -- ovsdb-client backup unix:/var/run/ovn/ovnsb_db.sock> \
+    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb
 
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c nbdb -- ovs-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/compact 
-
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}"  -c nbdb -- ls -lht /etc/ovn/ \
-    > "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb_size_post_compact
-
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}"  -c sbdb -- ls -lht /etc/ovn/ \
-    > "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb_size_post_compact
-
-    oc cp openshift-ovn-kubernetes/"${OVNKUBE_MASTER_POD}":/etc/ovn/ovnsb_db.db -c sbdb \
-    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb 2>&1 
-    gzip "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb 2>&1 & PIDS+=($!)
-    
-    oc cp openshift-ovn-kubernetes/"${OVNKUBE_MASTER_POD}":/etc/ovn/ovnnb_db.db -c nbdb \
-    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb 2>&1
-    
     gzip "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb 2>&1 & PIDS+=($!)
-    
+    gzip "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb 2>&1 & PIDS+=($!)
+
     oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}"  -c nbdb --  bash -c "ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status \
     OVN_Northbound" > "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_ovnnb_status_log & PIDS+=($!)
 

--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -169,15 +169,14 @@ function gather_ovn_kubernetes_master_data {
   PIDS+=($!)
 
   for OVNKUBE_MASTER_POD in ${OVNKUBE_MASTER_PODS[@]}; do
-    # ovsdb-client backup output does not include ephemeral columns, which by design
-    # do not survive across restarts of ovsdb-server.
-    # The database snapshot that it outputs is suitable to be served up directly by
-    # ovsdb-server or used as the input to ovsdb-client restore.
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c nbdb -- ovsdb-client backup unix:/var/run/ovn/ovnnb_db.sock > \
-    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb
-
-    oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c sbdb -- ovsdb-client backup unix:/var/run/ovn/ovnsb_db.sock> \
-    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb
+    # copy .db files, as this is the only way to get db information without interacting with ovsdb
+    # .db files contain both current db state and transactions info.
+    # to restore db from collected file use `ovsdb-tool cluster-to-standalone`
+    # (you will lose transactions data, but it is the only way to restore db) and then overwrite the database file
+    oc cp openshift-ovn-kubernetes/"${OVNKUBE_MASTER_POD}":/etc/ovn/ovnnb_db.db -c nbdb \
+    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb 2>&1
+    oc cp openshift-ovn-kubernetes/"${OVNKUBE_MASTER_POD}":/etc/ovn/ovnsb_db.db -c sbdb \
+    "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb 2>&1
 
     gzip "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_nbdb 2>&1 & PIDS+=($!)
     gzip "${NETWORK_LOG_PATH}"/"${OVNKUBE_MASTER_POD}"_sbdb 2>&1 & PIDS+=($!)


### PR DESCRIPTION
Change the way of gathering ovs db from compacting + copying db files to ovsdb-client backup.
This change should solve the following problems:
- copying the .db file might pick partial data
- even after compacting, it's not guaranteed that there are no transactions (which could happen after compacting and before copying the file). This makes it difficult for parsers other than ovsdb-server, e.g: insights.

Also, files from ovsdb-client backup may be used by ovsdb-client restore for local debugging.

Test:
Run must-gather, check `network_logs/<OVNKUBE_MASTER_POD>_nbdb.gz` and `network_logs/<OVNKUBE_MASTER_POD>_sbdb.gz` files.

Example of previous nbdb file:
```
OVSDB CLUSTER 147818 853ae92cae5be5e42481dc8f3d5a1fa390512145
{
        "cluster_id": "9f6509ea-c238-40c5-9c36-ade7b0c84b8c",
        "local_address": "ssl:10.0.140.173:9643",
        "name": "OVN_Northbound",
        "prev_data": [
             {
                "cksum": "2352750632 28701",
                "name": "OVN_Northbound",
                "tables": { ... },
                "version": "5.31.0"
            },
            {
                "ACL": {...},
                "Address_Set": {...},
                ...,
                "_comment": "compacting database online",
            }
        ],
        "prev_eid": "dfe07494-a8af-4c0d-88c0-5846733ad367",
        "prev_election_timer": 4000,
        "prev_index": 2543,
        "prev_servers": {
            "029b740c-993b-48f1-8c42-8b83c1cdd81e": "ssl:10.0.236.27:9643",
            "421f5dd9-8be4-4b8f-a951-ff1f91a7e0ed": "ssl:10.0.182.236:9643",
            "8aea2933-fc67-4b77-a2a9-fc4deccdafd5": "ssl:10.0.140.173:9643"
        },
        "prev_term": 21,
        "server_id": "8aea2933-fc67-4b77-a2a9-fc4deccdafd5"
    },
OVSDB CLUSTER 58 0d4b5064adad35db8615b6ed1ae18f71e8a81332
{
        "term": 21,
        "vote": "8aea2933-fc67-4b77-a2a9-fc4deccdafd5"
}
```

Example of current nbdb file (contains information from "prev_data" of old nbdb file):
```
OVSDB JSON 12282 edd18dab995cc426f8b957d0c20ab0b1e8079ffb
{
            "cksum": "2352750632 28701",
            "name": "OVN_Northbound",
            "tables": { ... },
            "version": "5.31.0"
}
OVSDB JSON 194111 882154e9ab233dc48ba3ef523db3bf220a7a5da1
{
            "ACL": {...},
            "Address_Set": {...},
            ...,
            "_comment": "produced by \"ovsdb-client backup\"",
        }
}
```
New version of db files also contains more fields, e.g.:
old version:
```
"ACL": {
           "002d0da5-d575-4e18-b1b3-4f6d335361b1": {
               "action": "allow-related",
                "direction": "to-lport",
                "match": "ip4.src==10.128.0.2",
                "name": "",
                "priority": 1001
         },
```
new version:
```
"ACL": {
            "002d0da5-d575-4e18-b1b3-4f6d335361b1": {
                "action": "allow-related",
                "direction": "to-lport",
                "external_ids": [
                    "map",
                    []
                ],
                "log": false,
                "match": "ip4.src==10.128.0.2",
                "meter": [
                    "set",
                    []
                ],
                "name": "",
                "priority": 1001,
                "severity": [
                    "set",
                    []
                ]
            },
```

About ephemeral columns - new db files contain ephemeral columns like Connection.is_connected https://github.com/ovn-org/ovn/blob/master/ovn-nb.ovsschema#L467 although [ovsdb-client backup docs](https://www.openvswitch.org/support/dist-docs/ovsdb-client.1.html) say
> The  output  does not include ephemeral columns, which by design do not survive across restarts of ovsdb-server.

```
"Connection": {
            "32a56ea9-b04e-491a-a811-0915ee0d52a3": {
                "external_ids": [
                    "map",
                    []
                ],
                "inactivity_probe": 60000,
                "is_connected": false,
                "max_backoff": [
                    "set",
                    []
                ],
                "other_config": [
                    "map",
                    []
                ],
                "status": [
                    "map",
                    []
                ],
                "target": "pssl:9641"
            }
        },
```
Not sure if it's the case, but [this link](https://docs.openvswitch.org/en/latest/ref/ovsdb.7/) says 
> Clustered OVSDB does not support the OVSDB “ephemeral columns” feature. ovsdb-tool and ovsdb-client change ephemeral columns into persistent ones when they work with schemas for clustered databases. Future versions of OVSDB might add support for this feature.