### PR TITLE
introduces a script for collecting kas static pod logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -70,5 +70,8 @@ oc adm inspect --dest-dir must-gather "${group_resources_text}"
 # Gather HAProxy config files
 /usr/bin/gather_haproxy_config
 
+# Gather kas startup and termination logs
+/usr/bin/gather_kas_startup_termination_logs
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_kas_startup_termination_logs
+++ b/collection-scripts/gather_kas_startup_termination_logs
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Downloads the startup.log and termination.log (and its rotated copies) from /var/logs/kube-apiserver on each master node
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+
+echo "WARNING: Collecting one or more kube-apiserver related logs on ALL masters in your cluster. This could take a large amount of time." >&2
+
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+paths=(kube-apiserver)
+for path in "${paths[@]}" ; do
+  output_dir="${BASE_COLLECTION_PATH}/static-pods/$path"
+  mkdir -p "$output_dir"
+  oc adm node-logs --role=master --path="$path" | \
+  grep -E '(startup.*.log|termination.log)' | \
+  sed "s|^|$path $output_dir |"
+done | \
+xargs --max-args=4 --max-procs=45 --no-run-if-empty bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
the logs are optional and stored at `/var/logs/kube-apiserver/startup.log` and `/var/logs/kube-apiserver/termination.log` on the host.

the script will save it under `must-gather/static-pods/kube-apiserver`