### PR TITLE
gather_audit_logs: fix oc command line to get the current audit profile

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -4,7 +4,7 @@
 # master node.
 BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 
-profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath=.spec.audit.profile)
+profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath='{.items[0].spec.audit.profile}')
 if [ -z "${profile}" ] || [ "${profile}" == None ]; then
   if [ "${1}" == "--force" ]; then
     cat <<EOF


### PR DESCRIPTION
The jsonpath command line was wrong. Thanks @wangke19 for finding the bug and providing the solution.