### PR TITLE
Bug 2014995: use single quotes instead of back quotes not to confuse shell

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -7,17 +7,17 @@ BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath='{.items[0].spec.audit.profile}')
 if [ -z "${profile}" ] || [ "${profile}" == None ]; then
   if [ "${1}" == "--force" ]; then
-    cat <<EOF
+    cat << EOF
 WARNING: To raise a Red Hat support request, it is required to set the top level audit policy to
          Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
-         be analyzed by support. Try `oc edit apiservers` and set `spec.audit.profile` back to
+         be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
          Default" and reproduce the issue while gathering audit logs.
 EOF
   else
-    cat <<EOF
+    cat << EOF
 ERROR: To raise a Red Hat support request, it is required to set the top level audit policy to
        Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
-       be analyzed by support. Try `oc edit apiservers` and set `spec.audit.profile` back to
+       be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
        "Default" and reproduce the issue while gathering audit logs. You can use "--force" to
        override this error.
 EOF


### PR DESCRIPTION
/assign @sttts 