### PR TITLE
collection-scripts: add script to collect CRI-O profiling data

### DIFF
--- a/collection-scripts/gather_node_util
+++ b/collection-scripts/gather_node_util
@@ -1,0 +1,81 @@
+#!/bin/bash
+# This file provides service functions to allow a common/centralized way to access a cluster node
+# to collect custom information from the host (it executes the requested commands via a debug pod).
+# The intended usage is:
+# 1) first add the commands to generate the files with the desired data/logs on the host (the node):
+#    use the "gather_node_util_add_command" function for that
+# 2) start the actual process by calling "gather_node_util_start" (for each node)
+# 3) retrieve the files from the host (node) with "gather_node_util_collect_file" (per node)
+# 4) stop the running pod with "gather_node_util_stop" (or it will stop by the deadline set on creation)
+# see gather_profiling as an example.
+
+GATHER_NODE_UTIL_CMDS=""
+
+# gather_node_util_reset_command
+gather_node_reutil_set_command() {
+    GATHER_NODE_UTIL_CMDS=""
+}
+
+# gather_node_util_add_command $COMMAND
+gather_node_util_add_command() {
+    local command="$1"
+
+    [ -z "$GATHER_NODE_UTIL_CMDS" ] \
+        && GATHER_NODE_UTIL_CMDS="${command}" \
+        || GATHER_NODE_UTIL_CMDS="${GATHER_NODE_UTIL_CMDS} && ${command}"
+}
+
+# gather_node_util_start $NODE [$TIMEOUT]
+gather_node_util_start() {
+    local node="$1"
+    local timeout="${2:-120}"
+    local debugPod=""
+
+    # Get debug pod's name
+	debugPod=$(oc debug --to-namespace=default node/${node} -o jsonpath='{.metadata.name}')
+    if [ -z "$debugPod" ]
+    then
+        echo "ERROR: cannot start debug pod for node ${node}"
+        return
+    fi
+
+    gather_node_util_add_command "sleep ${timeout}"
+    # Start the privileged pod
+    oc debug --to-namespace="default" node/${node} -- /bin/bash -c "${GATHER_NODE_UTIL_CMDS}" > /dev/null 2>&1 &
+}
+
+# gather_node_util_stop $NODE
+gather_node_util_stop() {
+    local node="$1"
+    local debugPod=""
+
+    # Get debug pod's name
+	debugPod=$(oc debug --to-namespace=default node/${node} -o jsonpath='{.metadata.name}')
+    [ -n "${debugPod}" ] && oc delete pod "$debugPod" -n "default" > /dev/null 2>&1
+}
+
+# gather_node_util_collect_file $NODE $SRC $DST [$TIMEOUT]
+gather_node_util_collect_file() {
+    local node="$1"
+    local file_src="$2"
+    local file_dst="$3"
+    local timeout="${4:-120}"
+    local retry_interval=10
+    local retry_num=$((timeout/retry_interval))
+    local debugPod=""
+
+    # Get debug pod's name
+    debugPod=$(oc debug --to-namespace=default node/${node} -o jsonpath='{.metadata.name}')
+    if [ -z "$debugPod" ]
+    then
+        echo "ERROR: cannot figure out debug pod for node ${node}"
+        return
+    fi
+
+    for i in $(seq 0 $retry_num)
+    do
+        oc cp -n default "${debugPod}:${file_src}" "${file_dst}" > /dev/null 2>&1
+        [ -f "$file_dst" ] && break
+        [ "$i" != "$retry_num" ] && sleep "${retry_interval}"
+    done
+}

--- a/collection-scripts/gather_profiling
+++ b/collection-scripts/gather_profiling
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+. gather_node_util
+
+# safeguards
+set -o nounset
+set -o pipefail
+
+# TODO: check which is the right "BASE_COLLECTION_PATH" to use
+BASE_COLLECTION_PATH="must-gather"
+
+
+# _gather_profiling_commands
+# Set the commands to be run on the node to collect profiling data.
+# Add here additional commands to be run on the node to generate profiling data (use "gather_node_util_add_command").
+_gather_profiling_commands() {
+    _gather_profiling_crio_commands
+}
+
+# _gather_profiling_collect_data_loop()
+# Define the remote files to retrieve and the local file to copy to (use "gather_node_util_collect_file").
+# This function will block till all the collection is over.
+_gather_profiling_collect_data_loop() {
+    local pids=()
+    local node
+
+    for node in ${NODES}; do
+        _gather_profiling_crio_collect_data "${node}" & pids+=($!)
+    done
+
+    echo "INFO: wait for profiling collection tasks"
+    wait ${pids[@]}
+    echo "INFO: completed profiling collection tasks"
+}
+
+
+# CRIO profiling
+CRIO_LOG_PATH="${BASE_COLLECTION_PATH}/pprof/crio"
+CRIO_REMOTE_TMP_PATH="/tmp/crio_pprof"
+CRIO_PROFILING_DURATION_SEC=30
+
+mkdir -p "$CRIO_LOG_PATH"
+
+_gather_profiling_crio_commands() {
+    local crio_curl_ep="curl --unix-socket /host/var/run/crio/crio.sock http://localhost/debug/pprof/"
+
+    gather_node_util_add_command "mkdir -p ${CRIO_REMOTE_TMP_PATH}"
+    gather_node_util_add_command "${crio_curl_ep}profile?seconds=${CRIO_PROFILING_DURATION_SEC} > ${CRIO_REMOTE_TMP_PATH}/prof.out"
+    gather_node_util_add_command "${crio_curl_ep}heap > ${CRIO_REMOTE_TMP_PATH}/heap.out"
+}
+
+_gather_profiling_crio_collect_data() {
+    local node="$1"
+
+    gather_node_util_collect_file "${node}" "${CRIO_REMOTE_TMP_PATH}/heap.out" "${CRIO_LOG_PATH}/${node}_heap.out"
+    gather_node_util_collect_file "${node}" "${CRIO_REMOTE_TMP_PATH}/prof.out" "${CRIO_LOG_PATH}/${node}_prof.out" 10
+}
+
+
+NODES="${@:-$(oc get nodes -o jsonpath='{.items[?(@.status.nodeInfo.operatingSystem=="linux")].metadata.name}')}"
+
+echo "INFO: GATHER PROFILING DATA"
+_gather_profiling_commands
+
+for node in ${NODES}; do
+    echo "INFO: start profiling tasks on node ${node}"
+    gather_node_util_start "${node}" &
+done
+
+_gather_profiling_collect_data_loop
+
+for node in ${NODES}; do
+    gather_node_util_stop "${node}" &
+done
+
+echo "INFO: gather profiling data completed"
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
This PR adds a script to collect profiling data from CRI-O on each node in the cluster.
This information may be helpful to diagnose container engine issues.