### PR TITLE
Collect rotated log files

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -41,9 +41,9 @@ resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconf
 
 # Run the Collection of Resources using inspect
 # running across all-namespaces for the few "Autoscaler" resources.
-oc adm inspect --dest-dir must-gather "${named_resources[@]}"
+oc adm inspect --dest-dir must-gather --rotated-pod-logs "${named_resources[@]}"
 group_resources_text=$(IFS=, ; echo "${group_resources[*]}")
-oc adm inspect --dest-dir must-gather "${group_resources_text}"
+oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text}"
 
 # Gather Insights Operator Archives
 /user/bin/gather_insights


### PR DESCRIPTION
Currently, the pod logs API does not expose [rotated logs](https://github.com/kubernetes/kubernetes/blob/b0bc8adbc2178e15872f9ef040355c51c45d04bb/pkg/kubelet/kuberuntime/logs/logs.go#L42). 
By using the flag introduced [here](https://github.com/openshift/oc/pull/958) must-gather will collect all of the available rotated log files for the selected containers.


Default OpenShift settings:
`containerLogMaxFiles: 5`
`containerLogMaxSize: 50Mi`
Rotation happens once current log file reaches `50Mi` in size and there can be up to 5 log files per container
**Although the rotated logs are [compressed](https://github.com/kubernetes/kubernetes/blob/91b7fb4dc9f5d98583ee63be51dac7b6c0704b10/pkg/kubelet/logs/container_log_manager.go#L289) this change may result in a significant size increase of the output directory.**


It should be removed once K8s supports getting the rotated logs through the API:
kubernetes/kubernetes#59902



Signed-off-by: Patryk Diak <pdiak@redhat.com>