### PR TITLE
RUNNING_ETCD_POD must not be a quorum pod for must-gather

### DIFF
--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -10,7 +10,7 @@ ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
 
 ETCDCTL_CONTAINER='etcdctl'
 
-RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running| grep -o -m 1 '\S*etcd\S*')
+RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running|grep -v quorum| grep -o -m 1 '\S*etcd\S*')
 
 # We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
 ETCDCTL_ENDPOINTS=$(oc exec "${RUNNING_ETCD_POD}"  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')


### PR DESCRIPTION
Picking a pod to run `etcdctl` commands on must be more selective, as `openshift-etcd` namespace started running "quorum-guard" pods as well. This change ensures the logic works no matter how the cluster nodes are named.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>