### PR TITLE
Bug 2041087: Revert MetalLB  speaker component label

### DIFF
--- a/collection-scripts/gather_metallb_logs
+++ b/collection-scripts/gather_metallb_logs
@@ -37,7 +37,7 @@ oc adm inspect --dest-dir must-gather "ns/${METALLB_NS}"
 get_metallb_cr
 
 # speaker pods are responsible for IP advertisement
-SPEAKER_PODS="${@:-$(oc -n ${METALLB_NS} get pods -l app.kubernetes.io/component=speaker -o jsonpath='{.items[*].metadata.name}')}"
+SPEAKER_PODS="${@:-$(oc -n ${METALLB_NS} get pods -l component=speaker -o jsonpath='{.items[*].metadata.name}')}"
 PIDS=()
 
 for SPEAKER_POD in ${SPEAKER_PODS[@]}; do


### PR DESCRIPTION
changing the MetalLB speaker component label back to the old
version as this change produced bugs on MetalLB and the label
was reverted there as well.

[changed from: app.kubernetes.io/component=speaker to: component=speaker]