### PR TITLE
Bug 2054319: Fix the namespace extract filter

### DIFF
--- a/collection-scripts/gather_metallb_logs
+++ b/collection-scripts/gather_metallb_logs
@@ -1,6 +1,6 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
-METALLB_NS=($(oc get subs -A --field-selector=metadata.name=metallb-operator -o jsonpath='{.items[*].metadata.namespace}'))
+METALLB_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "metallb-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
 METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${METALLB_NS}/pods"
 
 if [ -z "${METALLB_NS}" ]; then


### PR DESCRIPTION
Currently, the gather_metallb_logs script is extracting the operator
namespace by selecting the subscription with the metadata.name equal
to "metallb-operator". However, it would be more correct to check
against the spec.name that points to the name of the operator,
as the value of this field is constant. unlike the other that can
be called "metallb-operator-sub".

Note that I didn't use `--field-selector` in the new implementation
as spec.name field label is not supported.