### PR TITLE
List the pods by label app=etcd to only list etcd pods

### DIFF
--- a/collection-scripts/gather_etcd
+++ b/collection-scripts/gather_etcd
@@ -10,7 +10,7 @@ ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
 
 ETCDCTL_CONTAINER='etcdctl'
 
-RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers|grep Running|grep -v quorum| grep -o -m 1 '\S*etcd\S*')
+RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers -l app=etcd|grep Running| grep -o -m 1 '\S*etcd\S*')
 
 # We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
 ETCDCTL_ENDPOINTS=$(oc exec "${RUNNING_ETCD_POD}"  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')


### PR DESCRIPTION
Adding change to list the pods by label app=etcd to only list etcd pods. 
Also removing the need of greping -v the quorum pods.

Signed-off-by: Vladislav Walek <22072258+vwalek@users.noreply.github.com>