### PR TITLE
Bug 2062355: Collect NMState resources when operator is installed

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -82,5 +82,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text
 # Gather metallb logs
 /usr/bin/gather_metallb_logs
 
+# Gather NMState
+/usr/bin/gather_nmstate
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_nmstate
+++ b/collection-scripts/gather_nmstate
@@ -1,0 +1,28 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+NMSTATE_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "kubernetes-nmstate-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+NMSTATE_API_GROUP="nmstate.io"
+
+if [ -z "${NMSTATE_NS}" ]; then
+    echo "INFO: NMState not detected. Skipping."
+    exit 0
+fi
+
+function get_nmstate_cr() {
+    declare -a NMSTATE_CRDS=("nmstates" "nodenetworkconfigurationenactments" "nodenetworkconfigurationpolicies" "nodenetworkstates")
+    for NMSTATE_CRD in "${NMSTATE_CRDS[@]}"; do
+        CR_PATH="${BASE_COLLECTION_PATH}/cluster-scoped-resources/${NMSTATE_API_GROUP}/${NMSTATE_CRD}"
+        mkdir -p ${CR_PATH}
+
+        for CR_NAME in $(oc get ${NMSTATE_CRD} -ojsonpath='{.items[*].metadata.name}'); do
+            oc get ${NMSTATE_CRD} ${CR_NAME} -o yaml > "${CR_PATH}/${CR_NAME}.yaml"
+        done
+    done
+}
+
+oc adm inspect --dest-dir must-gather "ns/${NMSTATE_NS}"
+
+get_nmstate_cr
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
Currently we are missing the NMState resources in the must-gathers. This is especially a problem as the kubernetes-nmstate-operator became GA in 4.10. 
This PR addresses it and adds the NMState resources (namespace resources & CRs) to the must-gathers when the operator is installed.

**Hints for reviewers:**
I was following a similar approach to how MetalLB is collecting its resources ([./collection-scripts/gather_metallb_logs](https://github.com/openshift/must-gather/blob/master/collection-scripts/gather_metallb_logs)). If there is an easier way (e.g. by adding a certain annotation), please let me know.

**How to verify:**
1. Deploy a cluster and install the NMState operator (e.g. via the marketplace)
2. Add the NMState CR:
    ```
    cat <<EOF | oc apply -f -
    apiVersion: nmstate.io/v1
    kind: NMState
    metadata:
      name: nmstate
    EOF
    ```
3. Wait for the handler being deployed on all nodes (e.g. `oc -n openshift-nmstate get po -w`)
4. Add a simple nodenetworkconfigurationpolicy. e.g.:
    ```
    cat <<EOF | oc apply -f -
    apiVersion: nmstate.io/v1
    kind: NodeNetworkConfigurationPolicy
    metadata:
      name: br1-eth0
    spec:
      desiredState:
        interfaces:
        - name: br1
          type: linux-bridge
          state: up
          ipv4:
            dhcp: true
            enabled: true
          bridge:
            port:
            - name: eth0
    EOF
    ```
5. Collect the must-gathers and check for the nmstate resouces (e.g. `omg get nnce`)