### PR TITLE
Simplify CRD collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -80,7 +80,7 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text
 /usr/bin/gather_network_logs
 
 # Gather metallb logs
-/usr/bin/gather_metallb_logs
+/usr/bin/gather_metallb
 
 # Gather NMState
 /usr/bin/gather_nmstate

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -8,12 +8,11 @@ if [ -z "${METALLB_NS}" ]; then
     exit 0
 fi
 
-function get_metallb_cr() {
-    CR_PATH="${BASE_COLLECTION_PATH}/namespaces/${METALLB_NS}/cr"
-    mkdir ${CR_PATH}
-    declare -a CRS=("addresspools" "bgppeers" "bfdprofiles")
-    for CR in "${CRS[@]}"; do
-        oc get -n ${METALLB_NS} ${CR} -o yaml > ${CR_PATH}/${CR}.yaml
+function get_metallb_crs() {
+    declare -a METALLB_CRDS=("addresspools" "bgppeers" "bfdprofiles")
+    
+    for CRD in "${METALLB_CRDS[@]}"; do
+        oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n ${METALLB_NS} "${CRD}"
     done
 }
 
@@ -32,9 +31,8 @@ function gather_frr_logs() {
     done
 }
 
-oc adm inspect --dest-dir must-gather "ns/${METALLB_NS}"
-
-get_metallb_cr
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${METALLB_NS}"
+get_metallb_crs
 
 # speaker pods are responsible for IP advertisement
 SPEAKER_PODS="${@:-$(oc -n ${METALLB_NS} get pods -l component=speaker -o jsonpath='{.items[*].metadata.name}')}"

--- a/collection-scripts/gather_nmstate
+++ b/collection-scripts/gather_nmstate
@@ -1,28 +1,22 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
 NMSTATE_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "kubernetes-nmstate-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
-NMSTATE_API_GROUP="nmstate.io"
 
 if [ -z "${NMSTATE_NS}" ]; then
     echo "INFO: NMState not detected. Skipping."
     exit 0
 fi
 
-function get_nmstate_cr() {
+function get_nmstate_crs() {
     declare -a NMSTATE_CRDS=("nmstates" "nodenetworkconfigurationenactments" "nodenetworkconfigurationpolicies" "nodenetworkstates")
-    for NMSTATE_CRD in "${NMSTATE_CRDS[@]}"; do
-        CR_PATH="${BASE_COLLECTION_PATH}/cluster-scoped-resources/${NMSTATE_API_GROUP}/${NMSTATE_CRD}"
-        mkdir -p ${CR_PATH}
 
-        for CR_NAME in $(oc get ${NMSTATE_CRD} -ojsonpath='{.items[*].metadata.name}'); do
-            oc get ${NMSTATE_CRD} ${CR_NAME} -o yaml > "${CR_PATH}/${CR_NAME}.yaml"
-        done
+    for CRD in "${NMSTATE_CRDS[@]}"; do
+        oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
     done
 }
 
-oc adm inspect --dest-dir must-gather "ns/${NMSTATE_NS}"
-
-get_nmstate_cr
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${NMSTATE_NS}"
+get_nmstate_crs
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync


### PR DESCRIPTION
Make use of `oc adm inspect` to collect custom resources to align the
resource collection with the must-gather folder structure and not
have to set it up manually.

**Info for reviewers:**
MetalLB stores its CRs currently in `${BASE_COLLECTION_PATH}/namespaces/${METALLB_NS}/cr/${CRD_NAME}.yaml`. `oc adm inspect -n ${METALLB_NS} ${CRD}` will store it now in `${BASE_COLLECTION_PATH}/namespaces/${METALLB_NS}/<API_GROUP_NAME>/<API_RESOURCE_PLURAL>/<CR_NAME>.yaml` like described in the doc:

https://github.com/openshift/must-gather/blob/26dcac9e3454eba950b7a9c36abae8ee537e7f21/must-gather.md#L219-L226

**How to verify:**
* For NMState: Same procedure as in #292
* For MetalLB:
  * Deploy a cluster with this PR and install the MetalLB operator (e.g. into namespace metallb-system)
  * Create the MetalLB deployment:
    ````
    cat << EOF | oc apply -f -
    apiVersion: metallb.io/v1beta1
    kind: MetalLB
    metadata:
      name: metallb
      namespace: metallb-system
    EOF
    ````
  * Create an `AddressPool` object (or [`BGPPeer`](https://github.com/openshift/metallb-operator#create-a-bgp-peer-object) / [`BFDProfile`](https://github.com/openshift/metallb-operator#create-a-bfd-profile-object)):
    ````
    cat << EOF | oc apply -f -
    apiVersion: metallb.io/v1beta1
    kind: AddressPool
    metadata:
      name: addresspool-sample1
      namespace: metallb-system
    spec:
      protocol: layer2
      addresses:
        - 172.18.0.100-172.18.0.255
    EOF
    ````
  * Collect the must-gathers and check for the created resources
    ````
    oc adm must-gather --dest-dir=/tmp/mg
    omg use /tmp/mg
    omg get addresspool -n metallb-system
    ````