### PR TITLE
Add new metallb crds to the gather script

### DIFF
--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -9,7 +9,7 @@ if [ -z "${METALLB_NS}" ]; then
 fi
 
 function get_metallb_crs() {
-    declare -a METALLB_CRDS=("addresspools" "bgppeers" "bfdprofiles")
+    declare -a METALLB_CRDS=("addresspools" "bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
     
     for CRD in "${METALLB_CRDS[@]}"; do
         oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n ${METALLB_NS} "${CRD}"


### PR DESCRIPTION
MetalLB was introduced with 4 new CRDS:
bgpAdvertisements, ipaddresspools, l2advertisements and communities

This PR adds them to the collected CRs.