### PR TITLE
gather_profiling_node: correctly manage NotReady Nodes

### DIFF
--- a/collection-scripts/gather_profiling_node
+++ b/collection-scripts/gather_profiling_node
@@ -78,10 +78,12 @@ _gather_profiling_node_collect_crio_data() {
     local extract_timeout=$((PROFILING_NODE_SECONDS+300))
 
     _gather_profiling_node_start_crio_collection_pod "$node" "$pod_name"
-    oc wait --for=condition=Ready pod/${pod_name} --timeout=${extract_timeout}s \
-        && oc cp -c crio-prof-expose "${pod_name}:/tmp/pprof/" "$PROFILING_NODE_CRIO_LOG_PATH"
-
-    oc delete pod "$pod_name"
+    if oc wait --for=condition=Ready pod/${pod_name} --timeout=${extract_timeout}s; then
+        oc cp -c crio-prof-expose "${pod_name}:/tmp/pprof/" "$PROFILING_NODE_CRIO_LOG_PATH"
+        oc delete pod "$pod_name"
+    else
+        oc delete pod --grace-period=0 --force "$pod_name"
+    fi
 }
 
 _gather_profiling_node_collect_kubelet_data() {


### PR DESCRIPTION
When trying to collect CRI-O profiling data from a Node in the NotReady
state, the script gets stuck and will never complete, blocking on the
deletion of the CRI-O collection pod (which gets stuck in the  "Terminating"
state).
When the collection pod fails, force its deletion.

https://issues.redhat.com/browse/OCPNODE-983