### PR TITLE
[release-4.9] Bug 2092265: Add networking resources

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -241,6 +241,7 @@ elif [[ "${NETWORK_TYPE}" == "kuryr" ]]; then
     gather_kuryr_nodes_data
     gather_kuryr_data
 elif [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
+    oc adm inspect --dest-dir must-gather egressips.k8s.ovn.org
     if [ -z "$IPSEC_PODS" ]; then
         echo "INFO: No ovn-ipsec pods exist, tunnel traffic will be unencrypted"
     else 


### PR DESCRIPTION
Backport of https://github.com/openshift/must-gather/pull/307
In 4.9 `gather_scale_data` function is not present, skip that change
`openshift-cloud-network-config-controller` was only added from 4.10, skip that change too