### PR TITLE
Bug 2097346: Updates how gether_monitoring obtains SA token

### DIFF
--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -26,7 +26,7 @@ init() {
 
   # the SA token is used for authentication with Prometheus and Alert Manager
   # see: prom_get
-  SA_TOKEN="$(oc sa get-token default)"
+  SA_TOKEN="$(oc create token default)"
 
   # this is a CA bundle we need to verify the monitoring route,
   # we will write it to disk so we can use it in the flag


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2097346

problem: since k8s 1.24 tokens for SA are not automatically generated [1]
hence, it's not possible to get a SA token with the command
"oc sa get-token default", this breaks the gather_monitoring script as
we need the token to make http requests to prometheus

solution: use instead the new command "oc create token default"

[1] https://github.com/kubernetes/kubernetes/pull/108309