### PR TITLE
Stop collecting Docker logs on Windows instances

### DIFF
--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -2,9 +2,6 @@
 BASE_COLLECTION_PATH="/must-gather"
 WINDOWS_NODE_LOGS=$BASE_COLLECTION_PATH/host_service_logs/windows
 
-# Services logging to WinEvent log
-SERVICES=(docker)
-
 # Logfile list
 LOGS=(kube-proxy/kube-proxy.exe.INFO kube-proxy/kube-proxy.exe.ERROR kube-proxy/kube-proxy.exe.WARNING)
 LOGS+=(hybrid-overlay/hybrid-overlay.log kubelet/kubelet.log)
@@ -17,14 +14,7 @@ if [ -z "$WIN_NODES" ]; then
 fi
 
 PIDS=()
-LOG_WINEVENT_DIR=${WINDOWS_NODE_LOGS}/log_winevent/
-mkdir -p ${LOG_WINEVENT_DIR}
 echo INFO: Collecting logs for all Windows nodes
-for service in ${SERVICES[@]}; do
-    echo "INFO: Collecting WinEvent application logs for provider $service"
-    /usr/bin/oc adm node-logs -l kubernetes.io/os=windows -u $service > ${LOG_WINEVENT_DIR}/${service}_winevent.log &
-    PIDS+=($!)
-done
 for log in ${LOGS[@]}; do
     LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname $log)
     mkdir -p ${LOG_FILE_DIR}


### PR DESCRIPTION
With the switch to containerd as default runtime, we no longer want
to collect logs logs for the Docker Windows service.