### PR TITLE
Bug 2103283: Add timeout to oc cp command to fix must-gather delays when routers are terminating

### DIFF
--- a/collection-scripts/gather_haproxy_config
+++ b/collection-scripts/gather_haproxy_config
@@ -11,7 +11,7 @@ function gather_haproxy_config {
     for IC in ${INGRESS_CONTROLLERS}; do
         PODS=$(oc get pods -n openshift-ingress --no-headers -o custom-columns=":metadata.name" --selector ingresscontroller.operator.openshift.io/deployment-ingresscontroller="${IC}")
         for POD in ${PODS}; do
-            oc cp openshift-ingress/"${POD}":/var/lib/haproxy/conf/haproxy.config "${HAPROXY_CONFIG_PATH}"/"${IC}"/"${POD}"/haproxy.config &
+            timeout -v 3m oc cp openshift-ingress/"${POD}":/var/lib/haproxy/conf/haproxy.config "${HAPROXY_CONFIG_PATH}"/"${IC}"/"${POD}"/haproxy.config &
             PIDS+=($!)
         done
     done


### PR DESCRIPTION
This fixes a bug where if router pods are stuck in terminating when doing a must-gather, the must-gather will timeout instead of waiting for the router pods to terminate. More specifically, we have a bug in 4.10 CI in which the e2e-aws-operator job consistently fails on e2e-aws-operator-gather-must-gather container test due to pods stuck in the `terminating` state. 

Two reasons why this happens in CI:
1. If the `oc cp` command is ran on `terminating` pods, it will hang until the pod is deleted.
2. Router pods ignore SIGTERMs sent immediately after starting up and will get "stuck" in terminating state until the `terminationGracePeriodSeconds` sends a SIGKILL. This results in a number of old router pods just hanging out in the terminating state. Backport is pending for 4.10 https://bugzilla.redhat.com/show_bug.cgi?id=2098230.

Either way, seems like we should have a reasonable timeout on the `oc cp` command to protect against situations like this.