### PR TITLE
Bug 2106543: Correct typo in path name

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -46,7 +46,7 @@ group_resources_text=$(IFS=, ; echo "${group_resources[*]}")
 oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text}"
 
 # Gather Insights Operator Archives
-/user/bin/gather_insights
+/usr/bin/gather_insights
 
 # Gather monitoring data from the cluster
 /usr/bin/gather_monitoring


### PR DESCRIPTION
collection/gather script has a typo in the path name for the gather_insights call.  This PR fixes that issue.