### PR TITLE
Remove no longer needed gather_admission_webhooks script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -69,10 +69,6 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text
 # Gather etcd information
 /usr/bin/gather_etcd
 
-# Gather Validation and Mutating Admission Webhook Objects
-# TODO the kube-apiserver operator should list these as related resources
-/usr/bin/gather_admission_webhooks
-
 # Gather Service Logs (using a supplemental Script); Scoped to Masters.
 /usr/bin/gather_service_logs master
 

--- a/collection-scripts/gather_admission_webhooks
+++ b/collection-scripts/gather_admission_webhooks
@@ -1,7 +1,0 @@
-#!/bin/bash
-BASE_COLLECTION_PATH="/must-gather"
-WEB_HOOK_PATH="${BASE_COLLECTION_PATH}/web_hooks/"
-
-mkdir -p ${WEB_HOOK_PATH}
-oc get mutatingwebhookconfigurations -o yaml > ${WEB_HOOK_PATH}/mutatingwebhookconfigurations.yaml
-oc get validatingwebhookconfigurations -o yaml > ${WEB_HOOK_PATH}/validatingwebhookconfigurations.yaml


### PR DESCRIPTION
In 4.10, the webhooks info gathered by a part of kube-apiserver co.

```
$ oc version
Client Version: 4.10.22
Server Version: 4.10.22
Kubernetes Version: v1.23.5+3afdacb

$ oc get co kube-apiserver -o yaml
  - group: admissionregistration.k8s.io
    name: ""
    resource: mutatingwebhookconfigurations
  - group: admissionregistration.k8s.io
    name: ""
    resource: validatingwebhookconfigurations
$ ls ./must-gather/cluster-scoped-resources/admissionregistration.k8s.io/
mutatingwebhookconfigurations  validatingwebhookconfigurations
$ ls ./must-gather/web_hooks/
mutatingwebhookconfigurations.yaml  validatingwebhookconfigurations.yaml # duplicated info
```
