### PR TITLE
report correct version when multiple images invoked

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -2,7 +2,7 @@
 
 # generate /must-gather/version file
 . version
-echo "openshift/must-gather" > /must-gather/version
+echo "openshift/must-gather"> /must-gather/version
 version >> /must-gather/version
 
 # Named resource list, eg. ns/openshift-config

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 
 function version() {
-  # get version from image
-  version=$( \
-    oc status | grep '^pod' | \
-    sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
-  )
-
-  # if version not found, fallback to imageID
-  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
-
-  # if version still not found, use Unknown
-  [ -z "${version}" ] && version="Unknown"
-
-  echo ${version}
+  if [[ ! -z $OS_GIT_VERSION ]] ; then
+    echo "${OS_GIT_VERSION}"
+  else
+    echo "0.0.0-unknown"
+  fi
 }


### PR DESCRIPTION
Fix the generation of the `/must-gather/version` file such that if multiple must-gather images are invoked at once, the only the version of the currently running image will be recorded in the `/must-gather/version` file.

If a semantic-like version cannot be parsed from the image's `repository:tag` name (note that `:latest` is not a semantic-like version), use the imageID (typically a `repository@digest`) value.
