### PR TITLE
Bug 2000552: Add apiservices logs gathering by default

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -15,8 +15,8 @@ group_resources=()
 named_resources+=(ns/openshift-cluster-version)
 group_resources+=(clusterversion)
 
-# Operator Resources
-group_resources+=(clusteroperators)
+# Operator and APIService Resources
+group_resources+=(clusteroperators apiservices)
 
 # Certificate Resources
 group_resources+=(certificatesigningrequests)


### PR DESCRIPTION
Although there are ~73 apiservices available in standard OpenShift cluster,
 must-gather only gathers logs for 9 of them whose are defined
in openshift-kubeapiserver as `relatedObjects`. Other apiservices are either Local or defined as `relatedObjects` in none of other resources.

This PR adds `apiservices` log gatherig by default to easen troubleshooting.