### PR TITLE
Added PodNetworkConnectivityCheck gather script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -97,5 +97,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text
 # Gather SR-IOV resources
 /usr/bin/gather_sriov
 
+# Gather PodNetworkConnectivityCheck
+/usr/bin/gather_podnetworkconnectivitycheck
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_podnetworkconnectivitycheck
+++ b/collection-scripts/gather_podnetworkconnectivitycheck
@@ -4,6 +4,4 @@ POD_NETWORK_CHECK="${BASE_COLLECTION_PATH}/pod_network_connectivity_check/"
 
 mkdir -p ${POD_NETWORK_CHECK}
 
-for i in $(oc get PodNetworkConnectivityCheck -n openshift-network-diagnostics --no-headers | awk '{ print $1 }'); do
-    oc get PodNetworkConnectivityCheck -n openshift-network-diagnostics "$i" -o yaml > ${POD_NETWORK_CHECK}/"$i".yaml 
-done
+oc get podnetworkconnectivitychecks -n openshift-network-diagnostics -o yaml > ${POD_NETWORK_CHECK}/podnetworkconnectivitychecks.yaml

--- a/collection-scripts/gather_podnetworkconnectivitycheck
+++ b/collection-scripts/gather_podnetworkconnectivitycheck
@@ -1,0 +1,9 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="/must-gather"
+POD_NETWORK_CHECK="${BASE_COLLECTION_PATH}/pod_network_connectivity_check/"
+
+mkdir -p ${POD_NETWORK_CHECK}
+
+for i in $(oc get PodNetworkConnectivityCheck -n openshift-network-diagnostics --no-headers | awk '{ print $1 }'); do
+    oc get PodNetworkConnectivityCheck -n openshift-network-diagnostics "$i" -o yaml > ${POD_NETWORK_CHECK}/"$i".yaml 
+done


### PR DESCRIPTION
Added a script to collect PodNetworkConnectivityChecks to able to view the overall status of the pod network connectivity.

Current must-gather collects the contents of `openshift-network-diagnostics` but does not collect the PodNetworkConnectivityCheck.