### PR TITLE
Added hostsubnets to group_resources in gather script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -36,6 +36,9 @@ group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)
 
+# HostSubnet Resources
+group_resources+=(hostsubnets)
+
 # NodeNetworkState
 resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 


### PR DESCRIPTION
Adds HostSubnets to the `gather` script to resolve #298 

Sample output:
```bash
$ tree cluster-scoped-resources/network.openshift.io/
cluster-scoped-resources/network.openshift.io/
├── clusternetworks
 │   └── default.yaml
 └── hostsubnets
    ├── master-0.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── master-1.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── master-2.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── worker-0.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── worker-1.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    └── worker-2.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
```