### PR TITLE
Added hostsubnets to group_resources in gather_network_logs script

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -91,6 +91,8 @@ if [[ "${NETWORK_TYPE}" == "kuryr" ]]; then
 elif [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
     oc adm inspect --dest-dir must-gather egressips.k8s.ovn.org
     gather_ovn_kubernetes_data
+elif [[ "${NETWORK_TYPE}" == "openshiftsdn" ]]; then
+    oc adm inspect --dest-dir must-gather hostsubnets.network.openshift.io
 fi
 
 CNCC_DEPLOYMENT=$(oc get deployment -n openshift-cloud-network-config-controller --no-headers -o custom-columns=":metadata.name")


### PR DESCRIPTION
Adds HostSubnets to the `gather_network_logs` script to resolve #298 

Sample output:
```bash
$ tree cluster-scoped-resources/network.openshift.io/
cluster-scoped-resources/network.openshift.io/
├── clusternetworks
 │   └── default.yaml
 └── hostsubnets
    ├── master-0.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── master-1.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── master-2.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── worker-0.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    ├── worker-1.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
    └── worker-2.sharedocp4upi48.lab.upshift.rdu2.redhat.com.yaml
```

Submitted new PR after accidentally deleting the wrong branch. Previous PR #335 