### PR TITLE
OCPNODE-1499: Add CMA gather script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -96,5 +96,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text
 # Gather PodNetworkConnectivityCheck
 /usr/bin/gather_podnetworkconnectivitycheck
 
+# Gather CMA resources
+/usr/bin/gather_custom_metrics_autoscaler_logs
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_custom_metrics_autoscaler_logs
+++ b/collection-scripts/gather_custom_metrics_autoscaler_logs
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# safeguards
+set -o pipefail
+
+CMA_SUB_NAME="openshift-custom-metrics-autoscaler-operator"
+
+# find namespace
+CMA_NS=$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "'"${CMA_SUB_NAME}"'"}}{{.metadata.namespace}}{{end}}{{end}}')
+
+# check if namespace is present, exit otherwise
+if [ -z "${CMA_NS}" ]; then
+    echo "INFO: ${CMA_SUB_NAME} not detected. Skipping."
+    exit 0
+fi
+
+# init resource list
+resources=()
+
+# add resources in namespace
+resources+=(ns/${CMA_NS})
+
+# add custom resources
+resources+=(
+  kedacontroller
+  scaledjob
+  scaledobject
+  triggerauthentication
+  clustertriggerauthentication
+)
+
+# run the collection of resources using must-gather
+PIDS=()
+for resource in ${resources[@]}; do
+  echo "INFO: Processing $resource:" \
+    $(oc adm inspect --dest-dir must-gather --all-namespaces ${resource}) &
+  PIDS+=($!)
+done
+
+echo "INFO: Waiting for ${CMA_SUB_NAME} logs collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: ${CMA_SUB_NAME} logs collection completed"
+
+# force disk flush to ensure that all data gathered are written
+sync


### PR DESCRIPTION
This changes adds the gather script for the Custom Metrics Autoscaler (CMA) operator so that the operator resources are included in the must-gather if the operator is present.

Gathering the following:
- kedacontroller,
- scaledjob,
- scaledobject,
- triggerauthentication,
- clustertriggerauthentication and
- subscription namespace, e.g. ns/openshift-keda