### PR TITLE
OCPBUGS-7916: Back-port #259 to release 4.9

### DIFF
--- a/collection-scripts/gather_audit_logs
+++ b/collection-scripts/gather_audit_logs
@@ -4,20 +4,20 @@
 # master node.
 BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 
-profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath=.spec.audit.profile)
+profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath='{.items[0].spec.audit.profile}')
 if [ -z "${profile}" ] || [ "${profile}" == None ]; then
   if [ "${1}" == "--force" ]; then
-    cat <<EOF
+    cat << EOF
 WARNING: To raise a Red Hat support request, it is required to set the top level audit policy to
          Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
-         be analyzed by support. Try `oc edit apiservers` and set `spec.audit.profile` back to
+         be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
          Default" and reproduce the issue while gathering audit logs.
 EOF
   else
-    cat <<EOF
+    cat << EOF
 ERROR: To raise a Red Hat support request, it is required to set the top level audit policy to
        Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
-       be analyzed by support. Try `oc edit apiservers` and set `spec.audit.profile` back to
+       be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
        "Default" and reproduce the issue while gathering audit logs. You can use "--force" to
        override this error.
 EOF


### PR DESCRIPTION
The PR https://github.com/openshift/must-gather/pull/259 fixed the bug [2014995](https://bugzilla.redhat.com/show_bug.cgi?id=2014995), but we don't back-port it to release 4.9. It will cause the same issue with 4.9 release. This PR will back-port the code to 4.9 release, fixed the bug https://issues.redhat.com/browse/OCPBUGS-7916.