### PR TITLE
OCPBUGS-11147: network_logs: Gather multus resource yamls for namespaces

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -4,15 +4,14 @@ NETWORK_LOG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/network_logs"}
 
 mkdir -p "${NETWORK_LOG_PATH}"/
 
-function gather_multus_data { 
-  #Should we store this on a per namespace basis?
-  oc get net-attach-def -o yaml --all-namespaces > "${NETWORK_LOG_PATH}"/net_attach_def 2>&1 & PIDS+=($!)
+function gather_multus_data {
+  local resources=(ippools.whereabouts.cni.cncf.io overlappingrangeipreservations.whereabouts.cni.cncf.io \
+      net-attach-def multi-networkpolicy)
 
-  oc describe ippools.whereabouts.cni.cncf.io -A > "${NETWORK_LOG_PATH}"/ippools 2>&1 & PIDS+=($!)
-
-  oc describe overlappingrangeipreservations.whereabouts.cni.cncf.io -A > "${NETWORK_LOG_PATH}"/overlappingrangeipreservations  2>&1 & PIDS+=($!)
-
-  oc get multi-networkpolicy -o yaml --all-namespaces > "${NETWORK_LOG_PATH}"/multi_networkpolicy 2>&1 & PIDS+=($!)
+  for resource in "${resources[@]}"; do
+    oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${resource}" --all-namespaces 2>&1 || true & PIDS+=($!)
+    oc describe "${resource}" -A > "${NETWORK_LOG_PATH}"/"${resource}" || true 2>&1 & PIDS+=($!)
+  done
 }
 
 CLUSTER_NODES="${@:-$(oc get node -l node-role.kubernetes.io/master -oname)}"


### PR DESCRIPTION
Extend multus resource collection so that we gather all resources on a per namespace basis with `oc adm inspect`.
This way, users can create a combined must-gather with all resources in one place.

We might have to revisit this once the reconciler and other changes land in more recent version of multus, but for the time being I think that this is a good change to make that we can also bp to older versions

-------------------------

Test image with this change:
~~~
oc adm must-gather --image=quay.io/akaris/must-gather:take0 -- "/usr/bin/gather ; /usr/bin/gather_network_logs"
~~~

Here's the output of a test must-gather image with this change:
~~~
[akaris@linux 03402332]$ find must-gather.local.5408551214882970458/ -ipath '*network_logs*'
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/multus_logs
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/cluster_scale
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/ippools.whereabouts.cni.cncf.io
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_nbdb
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_nbdb.gz
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_ovnnb_status
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_ovnsb_status
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_sbdb
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/leader_sbdb.gz
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/multi-networkpolicy
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/net-attach-def
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/overlappingrangeipreservations.whereabouts.cni.cncf.io
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/ovn_kubernetes_top_pods
[akaris@linux 03402332]$ 
[akaris@linux 03402332]$ find must-gather.local.5408551214882970458/ -ipath '*ippools*'
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/ippools.whereabouts.cni.cncf.io.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/cluster-scoped-resources/apiserver.openshift.io/apirequestcounts/ippools.v1alpha1.whereabouts.cni.cncf.io.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/ippools
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/ippools/192.168.123.0-24.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/ippools.whereabouts.cni.cncf.io
[akaris@linux 03402332]$ find must-gather.local.5408551214882970458/ -ipath '*overlapping*'
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/overlappingrangeipreservations.whereabouts.cni.cncf.io.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/cluster-scoped-resources/apiserver.openshift.io/apirequestcounts/overlappingrangeipreservations.v1alpha1.whereabouts.cni.cncf.io.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.20.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.21.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.22.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.23.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.24.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.25.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.26.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.27.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.28.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.29.yaml
must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/network_logs/overlappingrangeipreservations.whereabouts.cni.cncf.io
~~~

~~~
[akaris@linux 03402332]$ cat must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/overlappingrangeipreservations/192.168.123.20.yaml
apiVersion: whereabouts.cni.cncf.io/v1alpha1
kind: OverlappingRangeIPReservation
metadata:
  creationTimestamp: "2023-03-30T12:10:24Z"
  generation: 1
  managedFields:
  - apiVersion: whereabouts.cni.cncf.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        .: {}
        f:containerid: {}
        f:podref: {}
    manager: whereabouts
    operation: Update
    time: "2023-03-30T12:10:24Z"
  name: 192.168.123.20
  namespace: openshift-multus
  resourceVersion: "57557"
  uid: c32159ac-b18b-46c9-85d1-4832b475dafc
spec:
  containerid: 3268f50add698e438bb0907f44ff567dea56f5f33de8cf1ceefb334625413e0e
  podref: default/netshoot-deployment-765cb7978-spv9d
[akaris@linux 03402332]$ cat must-gather.local.5408551214882970458/quay-io-akaris-must-gather-sha256-d471e64a4bc533628dfc2b4e68a8545f67c1bfbd52ba1ef1eb7af132824a8444/namespaces/openshift-multus/whereabouts.cni.cncf.io/ippools/192.168.123.0-24.yaml
apiVersion: whereabouts.cni.cncf.io/v1alpha1
kind: IPPool
metadata:
  creationTimestamp: "2023-03-30T12:10:24Z"
  generation: 17
  managedFields:
  - apiVersion: whereabouts.cni.cncf.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        .: {}
        f:allocations:
          .: {}
          f:20:
            .: {}
            f:id: {}
            f:podref: {}
          f:21:
            .: {}
            f:id: {}
            f:podref: {}
          f:22:
            .: {}
            f:id: {}
            f:podref: {}
          f:23:
            .: {}
            f:id: {}
            f:podref: {}
          f:24:
            .: {}
            f:id: {}
            f:podref: {}
          f:25:
            .: {}
            f:id: {}
            f:podref: {}
          f:26:
            .: {}
            f:id: {}
            f:podref: {}
          f:27:
            .: {}
            f:id: {}
            f:podref: {}
          f:28:
            .: {}
            f:id: {}
            f:podref: {}
          f:29:
            .: {}
            f:id: {}
            f:podref: {}
        f:range: {}
    manager: whereabouts
    operation: Update
    time: "2023-03-30T12:39:14Z"
  name: 192.168.123.0-24
  namespace: openshift-multus
  resourceVersion: "68042"
  uid: af3ed42a-757d-41be-93da-81bcd606ed92
spec:
  allocations:
    "20":
      id: 3268f50add698e438bb0907f44ff567dea56f5f33de8cf1ceefb334625413e0e
      podref: default/netshoot-deployment-765cb7978-spv9d
    "21":
      id: de8bc0872b8dbf81befe8f24f088bc2d88dfd1ab37a05b5b54006137659d48d5
      podref: default/netshoot-deployment-765cb7978-945wl
    "22":
      id: 19fd46fc3af203b5778e6271ba8e786402477593b954d77941bf6fcdf9fd7df3
      podref: default/netshoot-deployment-765cb7978-s4m5q
    "23":
      id: c3ae34489ac891c361ff918a140ba98a71b8ed6fbe7e14770e1b60d02ffc8e1a
      podref: default/netshoot-deployment-765cb7978-mwg9n
    "24":
      id: b2dac6de01c82ed858084bf5a99b1bf1d8cad866ce144a6989af2317e94ab27a
      podref: default/netshoot-deployment-765cb7978-52w4f
    "25":
      id: d2936b1b361bb2c57f4320ff04321d043cd19214284d04ed3d32fb8272db2f13
      podref: default/netshoot-deployment-765cb7978-mc4c4
    "26":
      id: 2503c94a374d9aeb37feab3f82bfae356dfae3787b6a20a9b56f0f25af292846
      podref: default/netshoot-deployment-765cb7978-6nmtl
    "27":
      id: 32c3c943fde577f71838f081eb8b4c9b4eefac24f5833838296fec22a30ef805
      podref: default/netshoot-deployment-765cb7978-8pxv5
    "28":
      id: 3e8c5a2681df4976c92e6b442965f0a0bfccb160f9c9704e3f2a7df395f20bde
      podref: default/netshoot-deployment-765cb7978-256k9
    "29":
      id: 0eab6fd93278eefdde411436d11d67d5b9ad3ab58f23c3e9663f0fa12df99be8
      podref: default/netshoot-deployment-765cb7978-lpdqm
  range: 192.168.123.0/24
~~~

~~~
[akaris@linux 03402332]$ omg get pods -n openshift-multus
NAME                                 READY  STATUS   RESTARTS  AGE
multus-74zqr                         1/1    Running  0         2h11m
multus-92qgf                         1/1    Running  0         2h1m
multus-additional-cni-plugins-667ht  1/1    Running  0         2h5m
multus-additional-cni-plugins-bmn5x  1/1    Running  0         2h11m
multus-additional-cni-plugins-c5nsx  1/1    Running  0         2h1m
multus-additional-cni-plugins-f2bds  1/1    Running  0         2h5m
multus-additional-cni-plugins-pw9bs  1/1    Running  0         2h11m
multus-additional-cni-plugins-xsgkv  1/1    Running  0         2h11m
multus-admission-controller-2hwh5    2/2    Running  0         2h6m
multus-admission-controller-9r5wn    2/2    Running  0         2h6m
multus-admission-controller-vwvnm    2/2    Running  0         2h5m
multus-b97vs                         1/1    Running  0         2h5m
multus-frn6s                         1/1    Running  0         2h11m
multus-j9c4l                         1/1    Running  0         2h11m
multus-p4psh                         1/1    Running  0         2h5m
network-metrics-daemon-7mwfb         2/2    Running  0         2h11m
network-metrics-daemon-9cvgv         2/2    Running  0         2h11m
network-metrics-daemon-9flvx         2/2    Running  0         2h11m
network-metrics-daemon-qpp5m         2/2    Running  0         2h5m
network-metrics-daemon-t7zxm         2/2    Running  0         2h1m
network-metrics-daemon-xhlt9         2/2    Running  0         2h5m
~~~