### PR TITLE
OCPBUGS-10798: Gather CSIStorageCapacity objects

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -11,6 +11,9 @@ named_resources=()
 # Resource groups list, eg. pods
 group_resources=()
 
+# Resources to gather with `--all-namespaces` option
+all_ns_resources=()
+
 # Cluster Version Information
 named_resources+=(ns/openshift-cluster-version)
 group_resources+=(clusterversion)
@@ -29,6 +32,7 @@ named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
 
 # Storage Resources
 group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)
+all_ns_resources+=(csistoragecapacities)
 
 # Image-source Resources
 group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
@@ -53,6 +57,8 @@ do
 done
 group_resources_text=$(IFS=, ; echo "${filtered_group_resources[*]}")
 oc adm inspect --dest-dir must-gather --rotated-pod-logs "${group_resources_text}"
+
+oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}" --all-namespaces
 
 # Gather Insights Operator Archives
 /usr/bin/gather_insights


### PR DESCRIPTION
Fixes: [must-gather does not contain CSIStorageCapacity](https://issues.redhat.com/browse/OCPBUGS-10798)

After building and deploying `must-gather` image to a cluster:
```
# /usr/bin/gather

# more must-gather/namespaces/hostpath-provisioner/storage.k8s.io/csistoragecapacities/csisc-586h8.yaml
apiVersion: storage.k8s.io/v1
capacity: 15442104Ki
kind: CSIStorageCapacity
maximumVolumeSize: 31970284Ki
metadata:
  creationTimestamp: "2023-03-01T10:25:09Z"
  generateName: csisc-
  labels:
    csi.storage.k8s.io/drivername: kubevirt.io.hostpath-provisioner
    csi.storage.k8s.io/managed-by: external-provisioner-crc-9ltqk-master-0
...
```