### PR TITLE
NETOBSERV-987: Add must gather script for network observability

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -102,5 +102,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather PodNetworkConnectivityCheck
 /usr/bin/gather_podnetworkconnectivitycheck
 
+# Gather Network Observerability logs
+/usr/bin/gather_network_observability
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_network_observability
+++ b/collection-scripts/gather_network_observability
@@ -1,0 +1,29 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+NO_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "netobserv-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+
+if [ -z "${NO_NS}" ]; then
+    echo "INFO: Network Observability namespace is not detected. Skipping."
+    exit 0
+fi
+
+function get_netobserv_cluster_crs() {
+    CRD="flowcollectors.flows.netobserv.io"
+    oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
+    obj=$(oc get ${CRD} -o custom-columns=:metadata.name --no-headers)
+    FC_NS=$(oc get ${CRD} ${obj} --output=jsonpath='{.spec.namespace}')
+}
+
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${NO_NS}"
+
+get_netobserv_cluster_crs
+if [ -z "${FC_NS}" ]; then
+    echo "INFO: Network Observability flow collector object namespace is not detected. Skipping."
+    exit 0
+fi
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${FC_NS}"
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${FC_NS}-privileged"
+
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
New script to collect netobservability logs and enable it by default
```shell
oc adm must-gather
```

Testing with cluster-bot
========================
1- Create must gather for network-observability
```shell
oc adm must-gather
```
2- Check the pods using `omg` tool
```shell
$ omg use must-gather.local.2028201061218736439/
Using:  /home/mmahmoud/data/test-noo-mg/must-gather.local.2028201061218736439/registry-build02-ci-openshift-org-ci-ln-tp5qw22-stable-sha256-da661034dc54b9943a1ce6c9b2abbb56c4ade39d1640ffe13a2f2a8e0867f7e0

$ omg get pods -n netobserv
NAME                               READY  STATUS   RESTARTS  AGE
flowlogs-pipeline-4f8t7            1/1    Running  0         6m53s
flowlogs-pipeline-7slt6            1/1    Running  0         6m53s
flowlogs-pipeline-dbgs4            1/1    Running  0         6m53s
flowlogs-pipeline-ncrzj            1/1    Running  0         6m53s
flowlogs-pipeline-p6n68            1/1    Running  0         6m53s
flowlogs-pipeline-qr554            1/1    Running  0         6m53s
netobserv-plugin-6f448c67d4-c4q4h  1/1    Running  0         6m54s
$ omg get pods -n netobserv-privileged
NAME                        READY  STATUS   RESTARTS  AGE
netobserv-ebpf-agent-2cljh  1/1    Running  0         6m55s
netobserv-ebpf-agent-2fm9j  1/1    Running  0         6m55s
netobserv-ebpf-agent-dsmgb  1/1    Running  0         6m55s
netobserv-ebpf-agent-vgstj  1/1    Running  0         6m55s
netobserv-ebpf-agent-vm7sq  1/1    Running  0         6m55s
netobserv-ebpf-agent-znr24  1/1    Running  0         6m55s
[mmahmoud@mmahmoud test-noo-mg]$ omg get pods -n openshift-netobserv-operator
NAME                                           READY  STATUS   RESTARTS  AGE
netobserv-controller-manager-566fb67dff-2blh5  2/2    Running  0         7m28s
```
3- Checking the flow collector object
```shell
cat cluster-scoped-resources/flows.netobserv.io/flowcollectors/cluster.yaml | head -n 10
apiVersion: flows.netobserv.io/v1beta1
kind: FlowCollector
metadata:
  creationTimestamp: "2023-04-13T16:47:35Z"
  finalizers:
  - flows.netobserv.io/finalizer
  generation: 2
  managedFields:
  - apiVersion: flows.netobserv.io/v1beta1
    fieldsType: FieldsV1
```