### PR TITLE
MCO-608: Gather MCO's on-disk configs from degraded nodes

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -105,6 +105,9 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather Network Observerability logs
 /usr/bin/gather_network_observability
 
+# Gather On-Disk MachineConfig files
+/usr/bin/gather_machineconfig_ondisk
+
 # Gather vSphere resources. This is NOOP on non-vSphere platform.
 /usr/bin/gather_vsphere
 

--- a/collection-scripts/gather_machineconfig_ondisk
+++ b/collection-scripts/gather_machineconfig_ondisk
@@ -1,0 +1,39 @@
+#!/bin/bash 
+
+BASE_COLLECTION_PATH="must-gather"
+MACHINECONFIG_CONFIG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/machine_config_ondisk"}
+
+mkdir -p "${MACHINECONFIG_CONFIG_PATH}"/
+
+# gather_machineconfig_ondisk_currentconfig collects the MCO's "on-disk" MachineConfig files
+function gather_machineconfig_ondisk {
+     
+    echo "INFO: Gathering on-disk MachineConfig from degraded nodes"
+    # we only really need the info from nodes that the MCO has marked as degraded 
+    MACHINECONFIG_DEGRADED_NODES=$(oc get node -o jsonpath='{.items[?(@.metadata.annotations.machineconfiguration\.openshift\.io/state=="Degraded")].metadata.name}')
+    # if kube-system/bootstrap is present, we're done bootstrapping
+    DONE_BOOTSTRAPPING=$(oc get configmap -n kube-system bootstrap)
+    for NODE in ${MACHINECONFIG_DEGRADED_NODES}; do
+         # use the existing MCD pod on the node to get the files
+         DAEMONPOD=$(oc get pods -n openshift-machine-config-operator --field-selector spec.nodeName=${NODE} --selector k8s-app=machine-config-daemon -o custom-columns=:metadata.name --no-headers)
+         if [ -z "$DONE_BOOTSTRAPPING" ]; then 
+            # collect the boostrap config that the Node got from the MCS (useless post-bootstrap)
+            timeout -v 3m oc cp -c machine-config-daemon openshift-machine-config-operator/"${DAEMONPOD}":rootfs/etc/mcs-machine-config-content.json "${MACHINECONFIG_CONFIG_PATH}"/"${NODE}"/mcs-machine-config-content.json &
+         else
+            # collect the Node's currentconfig that it believes it has applied (not present during bootstrap)
+            timeout -v 3m oc cp -c machine-config-daemon openshift-machine-config-operator/"${DAEMONPOD}":rootfs/etc/machine-config-daemon/currentconfig "${MACHINECONFIG_CONFIG_PATH}"/"${NODE}"/currentconfig &
+         fi
+         PIDS+=($!)
+    done
+
+}
+
+PIDS=()
+gather_machineconfig_ondisk
+
+echo "INFO: Waiting for on-disk MachineConfig collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: on-disk MachineConfig config collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
There have been a lot of Machine Config Operator (MCO)  bugs recently (e.g.  https://issues.redhat.com/browse/OCPBUGS-12741) where the MCO doesn't render the same thing during bootstrap and live operation, usually due to race conditions introduced elsewhere. 

We want these sorts of issues to cause degradation rather than silently succeed so we can catch rendering issues and race conditions, but troubleshooting them hurts a lot right now because there are on-disk files we need to see that we can't. (We often have to ask reporters/customers to manually collect the files for us) 

This PR adds a gather script that:
-  collects the on-disk `currentconfig` and `mcs-machine-config-content.json` from any node the MCO has marked degraded

With this, you end up with something like this in the must-gather for nodes the MCO has labeled with `machineconfiguration.openshift.io/state: Degraded
`  : 
```
must-gather/machine_config_ondisk
must-gather/machine_config_ondisk/ip-10-0-134-89.ec2.internal
must-gather/machine_config_ondisk/ip-10-0-134-89.ec2.internal/currentconfig
must-gather/machine_config_ondisk/ip-10-0-134-89.ec2.internal/mcs-machine-config-content.json
must-gather/machine_config_ondisk/ip-10-0-137-69.ec2.internal
must-gather/machine_config_ondisk/ip-10-0-137-69.ec2.internal/currentconfig
must-gather/machine_config_ondisk/ip-10-0-137-69.ec2.internal/mcs-machine-config-content.json
```
Note: 
- If there is an easier/better place I should do this, or I'm "doing it wrong"  let me know. :smile: 
- I don't have strong opinions on the directory hierarchy, I just want the file in the gather, I'll put it wherever you think is best 

/cc @yuqi-zhang 