### PR TITLE
Collect leases.coordination.k8s.io from each namesapce

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -43,6 +43,9 @@ group_resources+=(networks.operator.openshift.io)
 # NodeNetworkState
 resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
+# Leases
+all_ns_resources+=(leases)
+
 # Run the Collection of Resources using inspect
 # running across all-namespaces for the few "Autoscaler" resources.
 oc adm inspect --dest-dir must-gather --rotated-pod-logs "${named_resources[@]}"


### PR DESCRIPTION
This commit adds the leases resource to the list of resources to collect from all namespaces.

fixes #364 