### PR TITLE
Assert that only one subscription exists

### DIFF
--- a/collection-scripts/gather_ingress_node_firewall
+++ b/collection-scripts/gather_ingress_node_firewall
@@ -1,10 +1,15 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
-INGRESS_NODE_FIREWALL_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "ingress-node-firewall"}}{{.metadata.namespace}}{{end}}{{end}}')"
+INGRESS_NODE_FIREWALL_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "ingress-node-firewall"}}{{.metadata.namespace}}{{"\n"}}{{end}}{{end}}')"
 
 if [ -z "${INGRESS_NODE_FIREWALL_NS}" ]; then
     echo "INFO: Ingress node firewall namespace is not detected. Skipping."
     exit 0
+fi
+
+if [[ "$(echo "${INGRESS_NODE_FIREWALL_NS}" | wc -l)">1 ]]; then
+    echo "ERROR: found more than one ingress-node-firewall subscription. Exiting."
+    exit 1
 fi
 
 function get_ingress_node_firewall_namespaced_crs() {

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -1,11 +1,16 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
-METALLB_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "metallb-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+METALLB_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "metallb-operator"}}{{.metadata.namespace}}{{"\n"}}{{end}}{{end}}')"
 METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${METALLB_NS}/pods"
 
 if [ -z "${METALLB_NS}" ]; then
     echo "INFO: MetalLB not detected. Skipping."
     exit 0
+fi
+
+if [[ "$(echo "${METALLB_NS}" | wc -l)">1 ]]; then
+    echo "ERROR: found more than one metallb-operator subscription. Exiting."
+    exit 1
 fi
 
 function get_metallb_crs() {

--- a/collection-scripts/gather_network_observability
+++ b/collection-scripts/gather_network_observability
@@ -1,10 +1,15 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
-NO_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "netobserv-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+NO_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "netobserv-operator"}}{{.metadata.namespace}}{{"\n"}}{{end}}{{end}}')"
 
 if [ -z "${NO_NS}" ]; then
     echo "INFO: Network Observability namespace is not detected. Skipping."
     exit 0
+fi
+
+if [[ "$(echo "${NO_NS}" | wc -l)">1 ]]; then
+    echo "ERROR: found more than one netobserv-operator subscription. Exiting."
+    exit 1
 fi
 
 function get_netobserv_cluster_crs() {

--- a/collection-scripts/gather_nmstate
+++ b/collection-scripts/gather_nmstate
@@ -1,10 +1,15 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
-NMSTATE_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "kubernetes-nmstate-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+NMSTATE_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "kubernetes-nmstate-operator"}}{{.metadata.namespace}}{{"\n"}}{{end}}{{end}}')"
 
 if [ -z "${NMSTATE_NS}" ]; then
     echo "INFO: NMState not detected. Skipping."
     exit 0
+fi
+
+if [[ "$(echo "${NMSTATE_NS}" | wc -l)">1 ]]; then
+    echo "ERROR: found more than one kubernetes-nmstate-operator subscription. Exiting."
+    exit 1
 fi
 
 function get_nmstate_crs() {

--- a/collection-scripts/gather_sriov
+++ b/collection-scripts/gather_sriov
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 BASE_COLLECTION_PATH="must-gather"
-SRIOV_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "sriov-network-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+SRIOV_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "sriov-network-operator"}}{{.metadata.namespace}}{{"\n"}}{{end}}{{end}}')"
 SRIOV_LOG_PATH="${BASE_COLLECTION_PATH}/namespaces/${SRIOV_NS}"
 
 
 if [ -z "${SRIOV_NS}" ]; then
     echo "INFO: SR-IOV not detected. Skipping."
     exit 0
+fi
+
+if [[ "$(echo "${SRIOV_NS}" | wc -l)">1 ]]; then
+    echo "ERROR: found more than one sriov-network-operator subscription. Exiting."
+    exit 1
 fi
 
 # resource list


### PR DESCRIPTION
Users that mistakenly misconfigure and create two instances (or more)
of the subscription resource causes some gather scripts to fail.

For example, with 2 different sriov subscriptions, the SRIOV_NS will equal
"openshift-sriov-network-operatoropenshift-sriov-network-operator" which is invalid.

Here we add "{{\n}}" and with that, check whether we found more than
one subscription, and if so, exit with an error.

This fix is applied to all of the gather scripts that use this method:
ingress_node_firewall, metallb, network_observability, nmstate and sriov