### PR TITLE
gather_network_logs: multus: Fix typo in error redirection

### DIFF
--- a/collection-scripts/gather_network_logs
+++ b/collection-scripts/gather_network_logs
@@ -10,7 +10,7 @@ function gather_multus_data {
 
   for resource in "${resources[@]}"; do
     oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${resource}" --all-namespaces 2>&1 || true & PIDS+=($!)
-    oc describe "${resource}" -A > "${NETWORK_LOG_PATH}"/"${resource}" || true 2>&1 & PIDS+=($!)
+    oc describe "${resource}" -A > "${NETWORK_LOG_PATH}"/"${resource}" 2>&1 || true & PIDS+=($!)
   done
 }
 


### PR DESCRIPTION
As reported by surya:

~~~
not sure if you are the right person but pinging you based on : https://github.com/openshift/must-gather/pull/354 commit history :thread2:; when I run a must-gather on 4.14 latest I see:
error: the server doesn't have a resource type "multi-networkpolicy"                                                                                                         
error: the server doesn't have a resource type "multi-networkpolicy"                                                                                                         
which is not fatal but maybe we want to fix it to be smooth
~~~