### PR TITLE
Added gathering script for SNOs with workload partitioning

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -117,5 +117,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather Performance profile information
 /usr/bin/gather_ppc
 
+# Gather SNO resources
+/usr/bin/gather_sno
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_sno
+++ b/collection-scripts/gather_sno
@@ -1,0 +1,74 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+NODES_PATH=${OUT:-"${BASE_COLLECTION_PATH}/nodes"}
+
+function get_system_data_off_sno {
+
+    #Create a path for each node
+    mkdir -p "$NODES_PATH"/"$1"
+    
+    local DEBUG_POD_NAME_PREFIX=""
+
+    #Start Debug pod force it to stay up until removed in "default" namespace
+    oc debug --to-namespace="default" node/"$1" -- chroot /host /bin/bash -c 'sleep 300' > /dev/null 2>&1 &
+
+    #Debug pod name start with the name of the node (after removing all "." for the node name)
+    DEBUG_POD_NAME_PREFIX=${1//./}
+
+    #Mimic a normal oc call, i.e pause between two successive calls to allow pod to register
+    sleep 2
+
+    #Get the debug pod that is deployed in the default namespace on the specified node
+    debugPod=$(oc get pods --namespace=default -o jsonpath='{range .items[?(@.spec.nodeName=="'"$1"'")]}{.metadata.name}{"\n"}{end}' | grep "^${DEBUG_POD_NAME_PREFIX}-" | tail -n 1)
+
+    oc wait -n "default" --for=condition=Ready pod/"$debugPod"  --timeout=30s
+
+    if [ -z "$debugPod" ]
+    then
+      echo "Debug pod for node ""$1"" never activated"
+    else
+
+      #Collect systemctl list unit files
+      echo "Collecting list-unit-files"
+      oc exec "$debugPod" -n "default" -- chroot /host /bin/bash -c "systemctl list-unit-files" > "$NODES_PATH"/"$1"/list_units_files 
+      
+      echo "Collecting list-units"
+      oc exec "$debugPod" -n "default" -- chroot /host /bin/bash -c "systemctl list-units" > "$NODES_PATH"/"$1"/list_units 
+
+      #Collect /etc/crio directory
+      echo "Collecting /etc/crio"
+      oc cp  -n "default" "$debugPod":/host/etc/crio "$NODES_PATH"/"$1"/crio > /dev/null 2>&1
+
+      #clean up debug pod after we are done using them  
+      oc delete pod "$debugPod" -n "default"  
+    fi
+}
+
+function gather_system_data {
+  #Run system data collection on all nodes in parallel
+
+  mkdir -p "${NODES_PATH}"/
+
+  for NODE in ${NODES}; do
+    get_system_data_off_sno "${NODE}" & 
+    PIDS+=($!)
+  done
+}
+
+PIDS=()
+NODES="${*:-$(oc get nodes -o jsonpath='{.items[?(@.status.nodeInfo.operatingSystem=="linux")].metadata.name}')}"
+
+CPU_PARTITIONING=$(oc get infrastructure -o yaml | grep "CPUPartitioning" | awk '{print $2}')
+
+#Collects data if workload partitioning is enabled
+
+if [ "$CPU_PARTITIONING" = "AllNodes" ]; then
+  gather_system_data
+  echo "INFO: Waiting for SNO system data collection to complete ..."
+  wait "${PIDS[@]}"
+  echo "INFO: SNO system data collection complete."
+fi
+
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
This PR adds support for collecting data needed for validating SNO's with workload partitioning enabled. 

The scripts collects:
1. systemctl list-unit-files and systemctl list-unit, needed to check whether certain services are active or inactive.
2. CRIO directory to verify [workload partitioning is properly configured](https://github.com/openshift/enhancements/blob/1b69d46ae85f1e2952d4193fb77a9bb131d6907d/enhancements/workload-partitioning/management-workload-partitioning.md#cri-o-changes).

The script starts to collect these files only after checking [workload partitioning flags](https://github.com/openshift/api/blob/release-4.13/config/v1/types_infrastructure.go#L146) indicating the SNO has workload partitioning enabled.



https://issues.redhat.com/browse/TELCOSTRAT-156

 


