### PR TITLE
Added SNO with workload partitioning system data gathering script

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -117,5 +117,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather Performance profile information
 /usr/bin/gather_ppc
 
+# Gather SNO system data information
+/usr/bin/gather_sno
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_sno
+++ b/collection-scripts/gather_sno
@@ -1,7 +1,6 @@
 #!/bin/bash
 BASE_COLLECTION_PATH="must-gather"
 NODES_PATH=${OUT:-"${BASE_COLLECTION_PATH}/nodes"}
-NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
 function start_debug_pod_for_each_node {
 
@@ -11,7 +10,7 @@ function start_debug_pod_for_each_node {
     local DEBUG_POD_NAME_PREFIX=""
 
     #Start Debug pod force it to stay up until removed
-    oc debug --to-namespace="$NAMESPACE" node/"$1" -- chroot /host /bin/bash -c 'sleep 300' > /dev/null 2>&1 & 
+    oc debug node/"$1" -- chroot /host /bin/bash -c 'sleep 300' > /dev/null 2>&1 & 
 
 }
 
@@ -26,7 +25,7 @@ function get_system_data_of_node {
     while [ $counter -lt 3 ]
     do
       #Get the debug pod that is deployed in the MG namespace on the specified node
-      debugPod=$(oc get pods --namespace=$NAMESPACE -o jsonpath='{range .items[?(@.spec.nodeName=="'"$1"'")]}{.metadata.name}{"\n"}{end}' | grep "^${DEBUG_POD_NAME_PREFIX}-" | tail -n 1)
+      debugPod=$(oc get pods -o jsonpath='{range .items[?(@.spec.nodeName=="'"$1"'")]}{.metadata.name}{"\n"}{end}' | grep "^${DEBUG_POD_NAME_PREFIX}-" | tail -n 1)
 
       if [ -n "$debugPod" ]; then
         break 
@@ -41,18 +40,18 @@ function get_system_data_of_node {
     then
       echo "Debug pod for node ""$1"" never activated"
     else
-      oc wait -n "$NAMESPACE" --for=condition=Ready pod/"$debugPod"  --timeout=30s
+      oc wait --for=condition=Ready pod/"$debugPod"  --timeout=30s
 
       #Collect systemctl list unit files
       echo "Collecting list-unit-files"
-      oc exec "$debugPod" -n "$NAMESPACE" -- chroot /host /bin/bash -c "systemctl list-unit-files" > "$NODES_PATH"/"$1"/list_units_files 
+      oc exec "$debugPod" -- chroot /host /bin/bash -c "systemctl list-unit-files" > "$NODES_PATH"/"$1"/list_units_files 
       
       echo "Collecting list-units"
-      oc exec "$debugPod" -n "$NAMESPACE" -- chroot /host /bin/bash -c "systemctl list-units" > "$NODES_PATH"/"$1"/list_units 
+      oc exec "$debugPod" -- chroot /host /bin/bash -c "systemctl list-units" > "$NODES_PATH"/"$1"/list_units 
 
       #Collect /etc/crio directory
       echo "Collecting /etc/crio"
-      oc cp  -n "$NAMESPACE" "$debugPod":/host/etc/crio "$NODES_PATH"/"$1"/crio > /dev/null 2>&1
+      oc cp  "$debugPod":/host/etc/crio "$NODES_PATH"/"$1"/crio > /dev/null 2>&1
  
     fi
 }

--- a/collection-scripts/gather_sno
+++ b/collection-scripts/gather_sno
@@ -53,9 +53,7 @@ function get_system_data_of_node {
       #Collect /etc/crio directory
       echo "Collecting /etc/crio"
       oc cp  -n "$NAMESPACE" "$debugPod":/host/etc/crio "$NODES_PATH"/"$1"/crio > /dev/null 2>&1
-
-      #clean up debug pod after we are done using it
-      oc delete pod "$debugPod" -n "$NAMESPACE"  
+ 
     fi
 }
 

--- a/collection-scripts/gather_sno
+++ b/collection-scripts/gather_sno
@@ -77,9 +77,9 @@ function gather_system_data {
 PIDS=()
 NODES="${*:-$(oc get nodes -o jsonpath='{.items[?(@.status.nodeInfo.operatingSystem=="linux")].metadata.name}')}"
 
-CPU_PARTITIONING=$(oc get infrastructure -o yaml | grep "CPUPartitioning" | awk '{print $2}')
+CPU_PARTITIONING=$(oc get infrastructure -o=jsonpath='{.items[?(@.status.CPUPartitioning == "AllNodes")].status.CPUPartitioning}' | head -n 1 )
 
-Collects data if workload partitioning is enabled
+# Collects data if workload partitioning is enabled
 
 if [ "$CPU_PARTITIONING" = "AllNodes" ]; then
   gather_system_data

--- a/collection-scripts/gather_sno
+++ b/collection-scripts/gather_sno
@@ -1,0 +1,93 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+NODES_PATH=${OUT:-"${BASE_COLLECTION_PATH}/nodes"}
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+function start_debug_pod_for_each_node {
+
+    #Create a path for each node
+    mkdir -p "$NODES_PATH"/"$1"
+    
+    local DEBUG_POD_NAME_PREFIX=""
+
+    #Start Debug pod force it to stay up until removed
+    oc debug --to-namespace="$NAMESPACE" node/"$1" -- chroot /host /bin/bash -c 'sleep 300' > /dev/null 2>&1 & 
+
+}
+
+function get_system_data_of_node {
+
+    #Debug pod name start with the name of the node (after removing all "." for the node name)
+    DEBUG_POD_NAME_PREFIX=${1//./}
+ 
+    counter=0
+
+    #Allow 3 sec max for the debug pod to register 
+    while [ $counter -lt 3 ]
+    do
+      #Get the debug pod that is deployed in the MG namespace on the specified node
+      debugPod=$(oc get pods --namespace=$NAMESPACE -o jsonpath='{range .items[?(@.spec.nodeName=="'"$1"'")]}{.metadata.name}{"\n"}{end}' | grep "^${DEBUG_POD_NAME_PREFIX}-" | tail -n 1)
+
+      if [ -n "$debugPod" ]; then
+        break 
+      fi
+
+      counter=$((counter + 1))  
+      sleep 1  
+      
+    done
+
+    if [ -z "$debugPod" ]
+    then
+      echo "Debug pod for node ""$1"" never activated"
+    else
+      oc wait -n "$NAMESPACE" --for=condition=Ready pod/"$debugPod"  --timeout=30s
+
+      #Collect systemctl list unit files
+      echo "Collecting list-unit-files"
+      oc exec "$debugPod" -n "$NAMESPACE" -- chroot /host /bin/bash -c "systemctl list-unit-files" > "$NODES_PATH"/"$1"/list_units_files 
+      
+      echo "Collecting list-units"
+      oc exec "$debugPod" -n "$NAMESPACE" -- chroot /host /bin/bash -c "systemctl list-units" > "$NODES_PATH"/"$1"/list_units 
+
+      #Collect /etc/crio directory
+      echo "Collecting /etc/crio"
+      oc cp  -n "$NAMESPACE" "$debugPod":/host/etc/crio "$NODES_PATH"/"$1"/crio > /dev/null 2>&1
+
+      #clean up debug pod after we are done using it
+      oc delete pod "$debugPod" -n "$NAMESPACE"  
+    fi
+}
+
+function gather_system_data {
+  #Run system data collection on all nodes in parallel
+
+  mkdir -p "${NODES_PATH}"/
+
+  for NODE in ${NODES}; do
+    start_debug_pod_for_each_node "${NODE}" 
+  done
+  
+  for NODE in ${NODES}; do
+    get_system_data_of_node "${NODE}" & 
+    PIDS+=($!)
+  done
+}
+
+PIDS=()
+NODES="${*:-$(oc get nodes -o jsonpath='{.items[?(@.status.nodeInfo.operatingSystem=="linux")].metadata.name}')}"
+
+CPU_PARTITIONING=$(oc get infrastructure -o yaml | grep "CPUPartitioning" | awk '{print $2}')
+
+Collects data if workload partitioning is enabled
+
+if [ "$CPU_PARTITIONING" = "AllNodes" ]; then
+  gather_system_data
+  echo "INFO: Waiting for SNO system data collection to complete ..."
+  wait "${PIDS[@]}"
+  echo "INFO: SNO system data collection complete."
+fi
+
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
This PR continues this [PR](https://github.com/openshift/must-gather/pull/373) that got accidentally merged before being reviewed.
This introduces the following changes as suggested by @sferich888 :
1. The script uses the MG namespace, not the default NS.
2.  The script now has 3-sec max sleep per node, waiting for the pod to register. (1-sec sleep each time when the pod is not yet registered). This is instead of always waiting 2 seconds unconditionally. 
Note that, in most cases, only 0-1 sec sleep will be needed, after debug pod is created.  
 