### PR TITLE
Use oc get daemonset to identify the NTO image

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -39,7 +39,7 @@ function ppc_nodes() {
 
   # Find the NTO image reference
   # NTO contains all the tools needed here
-  NTO=$(oc adm release info --image-for=cluster-node-tuning-operator)
+  NTO=$(oc get deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator -o jsonpath="{.spec.template.spec.containers[0].image}")
   if [ $? -ne 0 ]; then
     echo "ERROR: Failed to identify the container image with node tools."
     echo "INFO: Node performance data collection will not contain node level data."


### PR DESCRIPTION
The previous method of using oc adm release info has been problematic for CI and restricted network environment clusters.

The issue was always the authentication to the registry and access to the release image from the inside of must-gather.

Also the oc adm release info tool runs inside a container and does not respect the node level ImageContentSourcePolicy.

For all these reasons I want to retrieve the image name from the configured NTO deployment instead.