### PR TITLE
NO-JIRA: Update gather_metallb

### DIFF
--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -24,7 +24,7 @@ function gather_frr_logs() {
 
     for COMMAND in "${COMMANDS[@]}"; do
         echo "###### ${COMMAND}" >> ${LOGS_DIR}/dump_frr
-        echo "$( timeout -v 60s oc -n ${operator_ns} exec ${1} -c frr -- vtysh -c "${COMMAND}")" >> ${LOGS_DIR}/dump_frr
+        echo "$( timeout -v 20s oc -n ${operator_ns} exec ${1} -c frr -- vtysh -c "${COMMAND}")" >> ${LOGS_DIR}/dump_frr
     done
 }
 

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -24,7 +24,7 @@ function gather_frr_logs() {
 
     for COMMAND in "${COMMANDS[@]}"; do
         echo "###### ${COMMAND}" >> ${LOGS_DIR}/dump_frr
-        echo "$( oc -n ${operator_ns} exec ${1} -c frr -- vtysh -c "${COMMAND}")" >> ${LOGS_DIR}/dump_frr
+        echo "$( timeout -v 60s oc -n ${operator_ns} exec ${1} -c frr -- vtysh -c "${COMMAND}")" >> ${LOGS_DIR}/dump_frr
     done
 }
 


### PR DESCRIPTION
Add a timeout in "oc exec -c frr -- vtysh -c ${COMMAND}" This command can block if vtysh is not responding properly and can put customer into a situation where mustgather can not be grabbed.