### PR TITLE
Collect running VMs count

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -117,5 +117,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather Performance profile information
 /usr/bin/gather_ppc
 
+# Gather Openshift Virtualization information
+/usr/bin/gather_virtualization
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_virtualization
+++ b/collection-scripts/gather_virtualization
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+BASE_COLLECTION_PATH="must-gather"
+get_operator_ns "kubevirt-hyperconverged"
+VIRTUALIZATION_PATH="${BASE_COLLECTION_PATH}/virtualization"
+mkdir -p "${VIRTUALIZATION_PATH}"
+
+function collect_running_vms_count() {
+  oc get vmi --all-namespaces -o=jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' | wc -w > "${VIRTUALIZATION_PATH}/running_vms_count.txt"
+}
+
+collect_running_vms_count


### PR DESCRIPTION
If Openshift Virtualization operator is installed, collect the number of running virtual machines in the cluster, across all namespaces. 

Jira-ticket: https://issues.redhat.com/browse/CNV-32855

/cc @sradco, @soltysh 