### PR TITLE
Add Prometheus queries collection

### DIFF
--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -104,6 +104,23 @@ alertmanager_get() {
       2> "$result_path.stderr"
 }
 
+prom_query() {
+  local query="$1"; shift
+  local path="${1:-$query}"; shift || true
+
+  local result_path="$MONITORING_PATH/queries/$path"
+  mkdir -p "$(dirname "$result_path")"
+
+  query_result="$(oc exec "${PROM_PODS[0]}" \
+    -c prometheus \
+    -n openshift-monitoring \
+    -- curl --silent --data-urlencode \
+    "query=${query}" \
+    http://localhost:9090/api/v1/query? | jq .)"
+
+  echo -e "Query: ${query}\n${query_result}" > "${result_path}.txt"
+}
+
 
 monitoring_gather(){
   init
@@ -124,6 +141,8 @@ monitoring_gather(){
   prom_get_from_replicas status/tsdb  || true
 
   alertmanager_get status  || true
+
+  prom_query "sum(cnv:vmi_status_running:count)" running_vms_count || true
 
   # force disk flush to ensure that all data gathered are written
   sync


### PR DESCRIPTION
This PR enhances `gather_monitoring` script to query Prometheus for requested queries, and adds these queries results to the collection. The suggested structure for these results in the MG dump is as follows:
```
-- monitoring 
---- queries
------ <query_description>.txt
```

**Example:** 
This PR adds the first query to be collected - `sum(cnv:vmi_status_running:count)`, and its result is collected to `monitoring/queries/running_vms_count.txt` as:
```
Query: sum(cnv:vmi_status_running:count)
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {},
        "value": [
          1696335577.967,
          "2"
        ]
      }
    ]
  }
}
```

**Notes:**
- `/monitoring` dir is not an addition of this PR.
- The script adds a `Query:  <query>` headline to each file. This is important because when we request a custom query (and not a metric/recording rule), the query is not part of the output. 
- The script prints the full output, and not only values, since queries results can be vectors with many different values, based on labels. Thus, the full output is useful.





Jira-ticket: https://issues.redhat.com/browse/CNV-33642

/cc @soltysh, @sradco, @dankenigsberg 

