### PR TITLE
OCPBUGS-19761: Removed workload partitioning annotation from ppc script

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -62,8 +62,6 @@ spec:
       name: perf-node-gather-daemonset
   template:
     metadata:
-      annotations:
-        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: perf-node-gather-daemonset
     spec:


### PR DESCRIPTION
This PR proposes a fix for this [bug](https://issues.redhat.com/browse/OCPBUGS-19761).
As @MarSik has commented, we believe the bug was created because the daemonset deploying pods with workload partitioning, whilst workload partitioning is not enabled for the MG temporary namespace.
To fix that, I removed the workload partitioning from the daemonset spec. Therefore, the pods that will now be deployed won't require workload partitioning to be enabled.