### PR TITLE
ppc: explicitly add RuntimeClass to gathered resources

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -192,7 +192,7 @@ resources=()
 resources+=(performanceprofile)
 
 # machine/node resources
-resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds)
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses)
 
 echo "INFO: Waiting for node performance related collection to complete ..."
 


### PR DESCRIPTION
PerformanceProfile creates a RuntimeClass.
It would be nice to have that in the must-gather information so lets explicitly gather that information in the script