### PR TITLE
sriov: Clean up `ip netns` output 

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 function get_operator_ns() {
     local operator_name=$(echo \"$1\")
     cmd="$(echo "oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name ""${operator_name}""}}{{.metadata.namespace}}{{\"\\n\"}}{{end}}{{end}}'")"

--- a/collection-scripts/gather_sriov
+++ b/collection-scripts/gather_sriov
@@ -28,7 +28,8 @@ function gather_netns_ip_a(){
   NETNS_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/netns"
   NETNS_IP_A_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/netns_ip_a"
 
-  oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- chroot /host /bin/bash -c "ip netns" > "${NETNS_LOG_PATH}" 2>&1 
+  # Filter out everything after network namespace name
+  oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- chroot /host /bin/bash -c "ip netns | sed "s/ .*//"" > "${NETNS_LOG_PATH}" 2>&1 
 
   while IFS= read -r id; do  
     echo "> ip netns exec ${id} ip a" >> "${NETNS_IP_A_LOG_PATH}" &&


### PR DESCRIPTION
`ip netns` output can have trailing strings after the
network namespace name, e.g.:

```
0e7432cc-0577-4e11-a88f-3ce8182dcd3f
f6f51cfd-02c5-45d7-917d-fc359d95df71
3ec15511-a387-40e6-a7c6-2de71b7bf880 (id: 27)
8ef1a9d8-be3f-44cb-9288-712eb3e4436f (id: 26)
```

Ensure every string after the space is filtered out.


Also, removing `set -e` statement from `common.sh`