### PR TITLE
MON-3108: Add out-of-the box metrics to gather_monitoring

### DIFF
--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source $(dirname "$0")/monitoring_common.sh
+
+metrics_gather "$@"

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -10,6 +10,7 @@ declare -r BASE_COLLECTION_PATH="../must-gather"
 declare -r MONITORING_PATH="${BASE_COLLECTION_PATH}/monitoring"
 declare -r CA_BUNDLE="${MONITORING_PATH}/ca-bundle.crt"
 
+source $(dirname "$0")/monitoring_common.sh
 
 # init initializes global variables that need to be computed.
 # E.g. get token of the default ServiceAccount
@@ -124,6 +125,11 @@ monitoring_gather(){
   prom_get_from_replicas status/tsdb  || true
 
   alertmanager_get status  || true
+
+  # get some metrics by default
+  get_metrics_min_time
+  # TODO: Add out of the box matchers.
+  metrics_gather --min-time=${promtool_min_time} --match=xxx || true
 
   # force disk flush to ensure that all data gathered are written
   sync

--- a/collection-scripts/monitoring_common.sh
+++ b/collection-scripts/monitoring_common.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# global readonly constants
+declare -r METRICS_PATH="../must-gather/monitoring/metrics"
+
+get_metrics_min_time() {
+  # default to the last 2h as Prometheus servs that from memory.
+  promtool_min_time=$(date --date='2 hours ago' +%s%3N)
+  # takes MUST_GATHER_SINCE into account.
+  # TODO: update description in "oc"
+  if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+    promtool_min_time=$(date --date=${MUST_GATHER_SINCE} +%s%3N)
+  fi
+}
+
+metrics_get() {
+  mkdir -p "${METRICS_PATH}"
+
+  readarray -t READY_PROM_PODS < <(
+    oc get pods -n openshift-monitoring  -l prometheus=k8s --field-selector=status.phase==Running \
+      --no-headers -o custom-columns=":metadata.name"
+  )
+  prometheus_pod=${READY_PROM_PODS[0]}
+  echo "INFO: Getting metrics from ${prometheus_pod}"
+
+  oc exec ${prometheus_pod} \
+    -c prometheus \
+    -n openshift-monitoring \
+    -- promtool tsdb dump-openmetrics /prometheus "$@" \
+       > "$METRICS_PATH/metrics.txt" \
+       2> "$METRICS_PATH/metrics.stderr"
+}
+
+# metrics_gather dumps metrics in OpenMetrics format at $METRICS_PATH.
+metrics_gather() {
+  if [ $# -eq 0 ]; then
+    echo "ERROR: Not setting any arguments will result in dumping all the metrics from the Prometheus instance.
+This script is not meant to do that, as it may negatively impact the Prometheus instance and the client running the script.
+
+At least one of the following arguments should be set:
+
+--min-time: Minimum timestamp to dump in ms. Defaults to -9223372036854775808.
+--max-time: Maximum timestamp to dump in ms. Defaults to 9223372036854775807.
+--match: Series selector. Can be specified multiple times. Defaults to {__name__=~'(?s:.*)'}.
+
+Please set them wisely."
+    exit 1
+  fi
+
+  metrics_get "$@" || true
+
+  # Force disk flush to ensure that all gathered data is written.
+  sync
+}


### PR DESCRIPTION
The required upstream Prs for this effort were merged and released:
- [x] https://github.com/prometheus/prometheus/pull/13296
- [x] https://github.com/prometheus/prometheus/pull/13218
- [x] https://github.com/prometheus/prometheus/pull/13194

---

https://github.com/openshift/must-gather/pull/434 adds the standalone `gather_metrics` script.
This PR is about out-of-the box metrics in `gather_monitoring`.

- [ ] Maybe the out-of-the box metrics should live in `gather_metrics` itself?)
