### PR TITLE
NO-JIRA: Add ARO support to must-gather client

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -114,5 +114,8 @@ oc adm inspect --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}
 # Gather Performance profile information
 /usr/bin/gather_ppc
 
+# Gather ARO information
+/usr/bin/gather_aro
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_aro
+++ b/collection-scripts/gather_aro
@@ -1,0 +1,22 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+ARO_CR_NAME="clusters.aro.openshift.io"
+
+IS_ARO=$(oc get ${ARO_CR_NAME} --ignore-not-found=true )
+if [ -z "$IS_ARO" ]; then
+    exit 0
+fi
+
+function gather_aro() {
+    echo "INFO: Collecting ARO Cluster Data"
+    declare -a INSPECT_TARGETS=(${ARO_CR_NAME} "ns/openshift-azure-operator" "ns/openshift-azure-logging")
+
+    for TARGET in "${INSPECT_TARGETS[@]}"; do
+        oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${TARGET}"
+    done
+}
+
+gather_aro
+
+# force disk flush to ensure that all data gathered are written
+sync


### PR DESCRIPTION
Azure Red Hat OpenShift (ARO) contains its own operator and custom resource, as well as a few additional namespaces on top of the base OCP. If accepted, this PR would collect this data if present or skip if not present, so that ARO customers can collect must-gathers that will help MCS and SRE debug ARO-specific issues.

Currently, this change is available in a custom must-gather image at `quay.io/cmarches/aro-must-gather`, but I wanted to propose adding the change upstream since ARO is an official OCP flavor and not all Azure customers will be able to pull a custom image from quay for compliance reasons.