### PR TITLE
OPNET-470: Collect host networking logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -112,6 +112,10 @@ pids+=($!)
 /usr/bin/gather_network_logs_basics &
 pids+=($!)
 
+# Gather host networking logs
+/usr/bin/gather_host_network_logs &
+pids+=($!)
+
 # Gather metallb logs
 /usr/bin/gather_metallb &
 pids+=($!)

--- a/collection-scripts/gather_host_network_logs
+++ b/collection-scripts/gather_host_network_logs
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+. gather_service_logs_util
+
+BASE_COLLECTION_PATH="/must-gather"
+HOST_NETWORK_NODE_LOGS=$BASE_COLLECTION_PATH/host_network_logs
+
+mkdir -p "${HOST_NETWORK_NODE_LOGS}"/
+
+PIDS=()
+echo "INFO: Collecting host networking logs"
+
+collect_service_logs --role=master "on-prem-resolv-prepender"
+collect_service_logs --role=worker "on-prem-resolv-prepender"
+
+collect_service_logs --role=master "nodeip-configuration"
+collect_service_logs --role=worker "nodeip-configuration"
+
+CLUSTER_NODES="${@:-$(oc get node -l node-role.kubernetes.io/master -oname)}"
+for NODE in ${CLUSTER_NODES}; do
+    nodefilename=$(echo "$NODE" | sed -e 's|node/||')
+    out=$(oc debug "${NODE}" -- \
+    /bin/bash -c "ip address" 2>/dev/null) && echo "$out" 1> "${HOST_NETWORK_NODE_LOGS}/ip-address-$nodefilename.log"
+    out=$(oc debug "${NODE}" -- \
+    /bin/bash -c "ip -4 route" 2>/dev/null) && echo "$out" 1> "${HOST_NETWORK_NODE_LOGS}/ip-route4-$nodefilename.log"
+    out=$(oc debug "${NODE}" -- \
+    /bin/bash -c "ip -6 route" 2>/dev/null) && echo "$out" 1> "${HOST_NETWORK_NODE_LOGS}/ip-route6-$nodefilename.log"
+done
+
+wait ${PIDS[@]}
+echo "INFO: Host networking log collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync


### PR DESCRIPTION
It happens very often that must-gather is the only bundle provided to the networking team when asking to help debugging various issues. In reality, in majority of those cases we would rather get sosreport and not must-gather because the former contains useful outputs from `ip` command.

With this PR we are trying to get the most basic networking informations already into must-gather to speed up debugging.

Contributes-to: [OPNET-470](https://issues.redhat.com//browse/OPNET-470)
Contributes-to: OCPBUGS-26217
Contributes-to: OCPBUGS-29624