### PR TITLE
NO-JIRA: Very minor change to trigger new image build to bump kubectl

### DIFF
--- a/must-gather.md
+++ b/must-gather.md
@@ -278,7 +278,7 @@ The image is included in the payload, but has no content running in a cluster to
 
 ### Version Skew Strategy
 
-The `oc` command must skew +/- one like normal commands.
+The `oc` command must skew +/- one like normal commands. 
 
 ## Implementation History
 


### PR DESCRIPTION
Currently must-gather image https://quay.io/repository/openshift/origin-must-gather/manifest/sha256:b36b9314580632d7eb4f4d5d71b1297eb637b91f84f0ab7df51137524f704228 refers to old kubectl version (1.28.2) for 4.16. This PR triggers new image build to bump kubectl version to 1.29.1 by performing a very minor change in this repo.