### PR TITLE
OCPBUGS-31037: Collect PerformanceProfile Data From all Nodes

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -124,6 +124,8 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pod-resources
           type: Directory
+      tolerations: 
+        - operator: Exists
 EOF
 
   COUNTER=0


### PR DESCRIPTION
Add toleration to perf-node-gather DaemonSet to ensure PerformanceProfile related data is collected from all nodes in a cluster.

The PerformanceProfileCreator tool, found within the Node Tuning Operator will return errors if the necessary files are missing for tainted cluster nodes. The data is collected using this DaemonSet in must-gather

Nodes are expected to be tainted for various reasons such as Infrastructure nodes, master nodes etc