### PR TITLE
SDN-4597: Add cluster scoped ANP resource to collection

### DIFF
--- a/collection-scripts/gather_network_logs_basics
+++ b/collection-scripts/gather_network_logs_basics
@@ -111,6 +111,8 @@ gather_scale_data
 
 if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
     oc adm inspect ${log_collection_args} --dest-dir must-gather egressips.k8s.ovn.org
+    oc adm inspect ${log_collection_args} --dest-dir must-gather adminnetworkpolicies.policy.networking.k8s.io
+    oc adm inspect ${log_collection_args} --dest-dir must-gather baselineadminnetworkpolicies.policy.networking.k8s.io
     gather_ovn_kubernetes_data
 elif [[ "${NETWORK_TYPE}" == "openshiftsdn" ]]; then
     oc adm inspect ${log_collection_args} --dest-dir must-gather hostsubnets.network.openshift.io


### PR DESCRIPTION
This PR adds support to must-gather for collecting crds of globally scoped resource: ANP.
See https://issues.redhat.com/browse/SDN-4157 for downstream details
See https://network-policy-api.sigs.k8s.io/reference/spec/ for API reference.

Tested on 4.16 cluster:
```
[must-gather-pc2zx] OUT ./cluster-scoped-resources/policy.networking.k8s.io/adminnetworkpolicies/node-as-egress-peers.yaml                                                   
[must-gather-pc2zx] OUT ./cluster-scoped-resources/policy.networking.k8s.io/adminnetworkpolicies/trial.yaml                                                                  
[must-gather-pc2zx] OUT ./cluster-scoped-resources/policy.networking.k8s.io/adminnetworkpolicies/trial3.yaml                                                                 
[must-gather-pc2zx] OUT ./cluster-scoped-resources/policy.networking.k8s.io/baselineadminnetworkpolicies/default.yaml
```

Collection seems to work as expected:
```
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io$ ls
adminnetworkpolicies  baselineadminnetworkpolicies
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io$ 
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io$ cd adminnetworkpolicies/
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io/adminnetworkpolicies$ ls
node-as-egress-peers.yaml  trial3.yaml  trial.yaml
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io/adminnetworkpolicies$ cd ..
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io$ cd baselineadminnetworkpolicies/
surya@hidden-temple:~/go/src/github.com/openshift/must-gather/must-gather.local.8142207633888895565/quay-io-itssurya-dev-images-sha256-52b9a1cd2a5cab9e57cccfc7cb4975e595bf0ef36a78852f26dc08506fcbd23d/cluster-scoped-resources/policy.networking.k8s.io/baselineadminnetworkpolicies$ ls
default.yaml
```