### PR TITLE
CNF-9168: MetalLB: adjust to support frrk8s and small fix

### DIFF
--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -7,7 +7,7 @@ get_log_collection_args
 METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}/pods"
 
 function get_metallb_crs() {
-    declare -a METALLB_CRDS=("addresspools" "bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
+    declare -a METALLB_CRDS=("bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
 
     for CRD in "${METALLB_CRDS[@]}"; do
         oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${operator_ns} "${CRD}"

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -8,7 +8,7 @@ METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}/pods"
 
 function get_metallb_crs() {
     declare -a METALLB_CRDS=("addresspools" "bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
-    
+
     for CRD in "${METALLB_CRDS[@]}"; do
         oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${operator_ns} "${CRD}"
     done
@@ -39,10 +39,10 @@ PIDS=()
 for SPEAKER_POD in ${SPEAKER_PODS[@]}; do
     gather_frr_logs ${SPEAKER_POD} &
     PIDS+=($!)
-    oc -n ${operator_ns} exec ${SPEAKER_POD} -c reloader -- sh -c "cat etc/frr_reloader/reloader.pid" > \
+    oc -n ${operator_ns} exec ${SPEAKER_POD} -c reloader -- sh -c "cat /etc/frr_reloader/reloader.pid" > \
     ${METALLB_PODS_PATH}/${SPEAKER_POD}/reloader/reloader/logs/reloader.pid &
     PIDS+=($!)
-done 
+done
 wait ${PIDS[@]}
 
 # force disk flush to ensure that all data gathered is accessible in the copy container

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -7,7 +7,7 @@ get_log_collection_args
 METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}/pods"
 
 function get_metallb_crs() {
-    declare -a METALLB_CRDS=("bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
+    declare -a METALLB_CRDS=("bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities" "frrconfiguration" "frrnodestate")
 
     for CRD in "${METALLB_CRDS[@]}"; do
         oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${operator_ns} "${CRD}"
@@ -32,15 +32,26 @@ function gather_frr_logs() {
 oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
 get_metallb_crs
 
-# speaker pods are responsible for IP advertisement
-SPEAKER_PODS="${@:-$(oc -n ${operator_ns} get pods -l component=speaker -o jsonpath='{.items[*].metadata.name}')}"
+
+if ! oc get metallb metallb -n ${operator_ns} > /dev/null 2>&1; then
+    echo "metallb not started"
+    exit 0
+fi
+
+BGP_BACKEND=$(oc get metallb metallb -n ${operator_ns} -o jsonpath='{.spec.bgpBackend}')
+
+if [ "$BGP_BACKEND" == "frr-k8s" ]; then
+	FRR_PODS="${@:-$(oc -n ${operator_ns} get pods -l component=frr-k8s -o jsonpath='{.items[*].metadata.name}')}"
+else
+	FRR_PODS="${@:-$(oc -n ${operator_ns} get pods -l component=speaker -o jsonpath='{.items[*].metadata.name}')}"
+fi
 PIDS=()
 
-for SPEAKER_POD in ${SPEAKER_PODS[@]}; do
-    gather_frr_logs ${SPEAKER_POD} &
+for POD in ${FRR_PODS[@]}; do
+    gather_frr_logs ${POD} &
     PIDS+=($!)
-    oc -n ${operator_ns} exec ${SPEAKER_POD} -c reloader -- sh -c "cat /etc/frr_reloader/reloader.pid" > \
-    ${METALLB_PODS_PATH}/${SPEAKER_POD}/reloader/reloader/logs/reloader.pid &
+    oc -n ${operator_ns} exec ${POD} -c reloader -- sh -c "cat /etc/frr_reloader/reloader.pid" > \
+    ${METALLB_PODS_PATH}/${POD}/reloader/reloader/logs/reloader.pid &
     PIDS+=($!)
 done
 wait ${PIDS[@]}


### PR DESCRIPTION
This PR adjusts the must gather collect script to reflect the latest metallb:

- it checks for the bgp backend and collect from the frr-k8s / speaker frr container according to the bgp backend
- it removes fetching the addresspool resource that was removed

Also, minor fix in fetching the pid from the right path.