### PR TITLE
OCPBUGS-32210: Collect Assisted Installer Namespace Logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -50,7 +50,7 @@ group_resources+=(networks.operator.openshift.io)
 resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
 # Assisted Installer
-resources+=(assisted-installer)
+all_ns_resources+=(ns/assisted-installer)
 
 # Leases
 all_ns_resources+=(leases)

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -49,6 +49,9 @@ group_resources+=(networks.operator.openshift.io)
 # NodeNetworkState
 resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
+# Assisted Installer
+resources+=(assisted-installer)
+
 # Leases
 all_ns_resources+=(leases)
 


### PR DESCRIPTION
Adds the namespace for the Assisted Installer to collect the Assisted Installer Operator logs when a must-gather is run.