### PR TITLE
NO-JIRA: Use oc rhel8 binary explicitly until base image is rhel9

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,6 +3,9 @@ WORKDIR /go/src/github.com/openshift/must-gather
 COPY . .
 ENV GO_PACKAGE github.com/openshift/must-gather
 
+FROM registry.ci.openshift.org/ocp/4.16:cli-artifacts as cli-artifacts
+
 FROM registry.ci.openshift.org/ocp/4.16:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
+COPY --from=cli-artifacts /usr/share/openshift/linux_amd64/oc.rhel8 /usr/bin/oc
 RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
must-gather includes oc invocations to gather some data and must-gather gets this oc from cli image. However, when we try to bump cli image to RHEL9, since must-gather is still on RHEL8, all oc invocations failed. This PR changes to use cli-artifacts image instead of cli. Thanks to that change, must-gather can explicitly uses oc.rhel8 and that decouples the cli and must-gather images for the future similar migrations.

example failures;

*  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/1752/pull-ci-openshift-oc-master-e2e-aws-ovn/1784837264291926016
* https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/1752/pull-ci-openshift-oc-master-e2e-agnostic-ovn-cmd/1784837260940677120