### PR TITLE
NO-JIRA: copy oc binary from cli-artifacts

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,5 +7,6 @@ FROM registry.ci.openshift.org/ocp/4.16:cli-artifacts as cli-artifacts
 
 FROM registry.ci.openshift.org/ocp/4.16:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
-COPY --from=cli-artifacts /usr/share/openshift/linux_amd64/oc.rhel8 /usr/bin/oc
+COPY --from=cli-artifacts /usr/bin/oc /usr/bin/oc
+
 RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
additional work for https://github.com/openshift/must-gather/pull/418 to copy multi-arch oc binaries.