### PR TITLE
WRKLDS-1251: Use oc.rhel8 based on the target arch of image

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,5 +7,10 @@ FROM registry.ci.openshift.org/ocp/4.16:cli-artifacts as cli-artifacts
 
 FROM registry.ci.openshift.org/ocp/4.16:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
-COPY --from=cli-artifacts /usr/share/openshift/linux_amd64/oc.rhel8 /usr/bin/oc
+COPY --from=cli-artifacts /usr/share/openshift/linux_amd64/oc.rhel8 /usr/share/openshift/linux_amd64/oc
+COPY --from=cli-artifacts /usr/share/openshift/linux_arm64/oc.rhel8 /usr/share/openshift/linux_arm64/oc
+COPY --from=cli-artifacts /usr/share/openshift/linux_ppc64le/oc.rhel8 /usr/share/openshift/linux_ppc64le/oc
+
+RUN ln -sf /usr/share/openshift/linux_$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/oc /usr/bin/oc
+
 RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
This PR uses the correct oc.rhel8 binary based on the image's architecture. This is the follow up of https://github.com/openshift/must-gather/pull/418