### PR TITLE
OCPBUGS-34360: Run ppc node collection in parallel

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -139,6 +139,7 @@ EOF
   done
 
   COLLECTABLE_NODES=()
+  NODE_PIDS=()
   for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers -l name=perf-node-gather-daemonset --field-selector=status.phase=Running -n $NAMESPACE)
   do
       node=$(echo $line | awk -F ' ' '{print $1}')
@@ -146,24 +147,13 @@ EOF
       NODE_PATH=${NODES_PATH}/$node
       mkdir -p "${NODE_PATH}"
 
-      echo "Collecting performance related data for node $line"
-
-      oc exec $pod -n $NAMESPACE -- lspci -nvv > $NODE_PATH/lspci
-      oc exec $pod -n $NAMESPACE -- lscpu -e > $NODE_PATH/lscpu
-      oc exec $pod -n $NAMESPACE -- cat /proc/cmdline > $NODE_PATH/proc_cmdline
-      oc exec $pod -n $NAMESPACE -- dmesg > $NODE_PATH/dmesg
-      oc exec $pod -n $NAMESPACE -- ethtool -k eth0 > $NODE_PATH/ethtool_features
-      oc exec $pod -n $NAMESPACE -- ethtool -l eth0 > $NODE_PATH/ethtool_channels
-
       COLLECTABLE_NODES+=($node)
 
-      oc exec $pod -n $NAMESPACE -- gather-sysinfo --json cpuaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/cpu_affinities.json
-      oc exec $pod -n $NAMESPACE -- gather-sysinfo --json irqaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/irq_affinities.json
-      oc exec $pod -n $NAMESPACE -- gather-sysinfo --json podres --socket-path=unix:///host/podresources/kubelet.sock > $NODE_PATH/podresources.json
-
-      oc exec $pod -n $NAMESPACE -- gather-sysinfo snapshot --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
-      oc exec $pod -n $NAMESPACE -- gather-sysinfo podinfo --node-name $node > $NODE_PATH/pods_info.json
+      # Run per node data collection in parallel
+      timeout -k 1m 5m /usr/bin/gather_ppc_single_node "${pod}" "${NAMESPACE}" "${node}" "${NODE_PATH}" &
+      NODE_PIDS+=($!)
   done
+  wait "${NODE_PIDS[@]}"
 
   # Collect journal logs for specified units for all nodes
   NODE_UNITS=(kubelet)
@@ -172,6 +162,7 @@ EOF
       NODE_PATH=${NODES_PATH}/$NODE
       mkdir -p ${NODE_PATH}
       for UNIT in ${NODE_UNITS[@]}; do
+          echo "Collecting ${UNIT} logs for node ${NODE}"
           timeout -k 5m 30m bash -c "oc adm node-logs \"${node_log_collection_args:---since=-8h}\" $NODE -u $UNIT | gzip" > ${NODE_PATH}/${NODE}_logs_$UNIT.gz &
           ADM_PIDS+=($!)
       done

--- a/collection-scripts/gather_ppc_single_node
+++ b/collection-scripts/gather_ppc_single_node
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is not supposed to be executed manually. It is used from
+# the gather_ppc collection script.
+
+pod=$1
+NAMESPACE=$2
+node=$3
+NODE_PATH=$4
+
+echo "Collecting performance related data for node $node"
+
+oc exec $pod -n $NAMESPACE -- lspci -nvv > $NODE_PATH/lspci
+oc exec $pod -n $NAMESPACE -- lscpu -e > $NODE_PATH/lscpu
+oc exec $pod -n $NAMESPACE -- cat /proc/cmdline > $NODE_PATH/proc_cmdline
+oc exec $pod -n $NAMESPACE -- dmesg > $NODE_PATH/dmesg
+oc exec $pod -n $NAMESPACE -- ethtool -k eth0 > $NODE_PATH/ethtool_features
+oc exec $pod -n $NAMESPACE -- ethtool -l eth0 > $NODE_PATH/ethtool_channels
+
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json cpuaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/cpu_affinities.json
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json irqaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/irq_affinities.json
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json podres --socket-path=unix:///host/podresources/kubelet.sock > $NODE_PATH/podresources.json
+
+oc exec $pod -n $NAMESPACE -- gather-sysinfo snapshot --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
+oc exec $pod -n $NAMESPACE -- gather-sysinfo podinfo --node-name $node > $NODE_PATH/pods_info.json


### PR DESCRIPTION
The PPC node data collection was running in serial and that increased the time needed to collect the whole cluster. This change executes each per-node sequence in parallel and waits for all the sub tasks.

The only disadvantage is having a per-node process (potentially hundreds in huge clusters), however this case has always been lower in the code as well. The load on the controlling must-gather pod should be low as it only executes remote commands and waits for results.

This can be tested (at least while the PR is open) by executing:

```
oc adm must-gather --image quay.io/msivak/must-gather:test416c
```

Thanks to our scale testing colleagues we have a comparison between the stock and the parallelized runs using OCP 4.16.0-rc.3 on a cluster with 120 worker nodes.

stock:

```
$ time oc adm must-gather
real    48m39.426s
user    0m30.998s
sys     0m14.527s
file size:5969MB
```

with PR applied:

```
$ time oc adm must-gather --image quay.io/msivak/must-gather:test416c
[must-gather      ] OUT 2024-06-06T00:55:35.965950772Z Using must-gather plug-in image: quay.io/msivak/must-gather:test416c
real    8m16.947s
user    0m34.009s
sys     0m16.852s
file size:6993MB (I checked, the size is fine, one extra hour of run time generated some extra logs on the cluster)
```