### PR TITLE
OCPBUGS-43894: Avoids to collect frr.log for MetalLB

### DIFF
--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -15,7 +15,7 @@ function get_metallb_crs() {
 }
 
 function gather_frr_logs() {
-    declare -a FILES_TO_GATHER=("frr.conf" "frr.log" "daemons" "vtysh.conf")
+    declare -a FILES_TO_GATHER=("frr.conf" "daemons" "vtysh.conf")
     declare -a COMMANDS=("show running-config" "show bgp ipv4" "show bgp ipv6" "show bgp neighbor" "show bfd peer")
     LOGS_DIR="${METALLB_PODS_PATH}/${1}/frr/frr/logs"
 


### PR DESCRIPTION
Entire frr.log files collected by the gather_metallb can be huge in size (several GB) and in case of clusters with a lot of nodes the must-gather size can grow easily to an unreasonable size to be shared.
Part of the frr logs are already into the regular container logs, I believe that in case these logs are really needed for troubleshooting we can still ask for them.

I'm proposing here to remove the frr.log files collection from the gather_metallb script, this will drastically improve the size of the must-gather.