### PR TITLE
OCPBUGS-34323: Collection-scripts as go package

### DIFF
--- a/collection-scripts/doc.go
+++ b/collection-scripts/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_must_gather


### PR DESCRIPTION
Related jira ticket https://issues.redhat.com/browse/OCPBUGS-34323

[Local-storage-operator](https://github.com/openshift/local-storage-operator/tree/master/must-gather) and [secrets-store-csi-driver-operator](https://github.com/openshift/secrets-store-csi-driver-operator/tree/main/must-gather) must-gather plugins now have a copy  of [common.sh from must-gather repo](https://github.com/openshift/must-gather/blob/master/collection-scripts/common.sh). If there is a bugfix in that script, we must copy it manually. 

We decided the most optimal way for us to have the script up to date is using go vendoring and making the collection-scripts as a go package. This means we need to add go file, marking it as a package. 

We are already using this trick in [Build Machinery Go](https://github.com/openshift/cluster-storage-operator/tree/master/vendor/github.com/openshift/build-machinery-go) where we add it to go.mod and import it in dir [Dependency magnet](https://github.com/openshift/cluster-storage-operator/blob/master/pkg/dependencymagnet/dependencymagnet.go) and the scripts (in this example makefiles) are downloaded.