### PR TITLE
MON-3108: Add gather_metrics for Prometheus fetching

### DIFF
--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source $(dirname "$0")/monitoring_common.sh
+
+metrics_gather "$@"

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -10,6 +10,7 @@ declare -r BASE_COLLECTION_PATH="../must-gather"
 declare -r MONITORING_PATH="${BASE_COLLECTION_PATH}/monitoring"
 declare -r CA_BUNDLE="${MONITORING_PATH}/ca-bundle.crt"
 
+source $(dirname "$0")/monitoring_common.sh
 
 # init initializes global variables that need to be computed.
 # E.g. get token of the default ServiceAccount
@@ -124,6 +125,9 @@ monitoring_gather(){
   prom_get_from_replicas status/tsdb  || true
 
   alertmanager_get status  || true
+
+  # TODO: Add out of the box metrics.
+  # metrics_gather --min-time=${promtool_min_time} --match=xxx || true
 
   # force disk flush to ensure that all data gathered are written
   sync

--- a/collection-scripts/monitoring_common.sh
+++ b/collection-scripts/monitoring_common.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# global readonly constants
+declare -r METRICS_PATH="../must-gather/monitoring/metrics"
+
+metrics_get() {
+  mkdir -p "${METRICS_PATH}"
+
+  readarray -t READY_PROM_PODS < <(
+    oc get pods -n openshift-monitoring  -l prometheus=k8s --field-selector=status.phase==Running \
+      --no-headers -o custom-columns=":metadata.name"
+  )
+  prometheus_pod=${READY_PROM_PODS[0]}
+  echo "INFO: Getting metrics from ${prometheus_pod}"
+
+  oc exec ${prometheus_pod} \
+    -c prometheus \
+    -n openshift-monitoring \
+    -- promtool tsdb dump-openmetrics /prometheus "$@" \
+       > "$METRICS_PATH/metrics.openmetrics" \
+       2> "$METRICS_PATH/metrics.stderr"
+}
+
+# metrics_gather dumps metrics in OpenMetrics format at $METRICS_PATH.
+metrics_gather() {
+  if [ $# -eq 0 ]; then
+    echo "ERROR: Not setting any arguments will result in dumping all the metrics from the Prometheus instance.
+This script is not meant to do that, as it may negatively impact the Prometheus instance and the client running the script.
+
+At least one of the following arguments should be set:
+
+--min-time: Minimum timestamp to dump in ms. Defaults to -9223372036854775808.
+--max-time: Maximum timestamp to dump in ms. Defaults to 9223372036854775807.
+--match: Series selector. Can be specified multiple times. Defaults to {__name__=~'(?s:.*)'}.
+
+Please set them wisely."
+    exit 1
+  fi
+
+  metrics_get "$@" || true
+
+  # Force disk flush to ensure that all gathered data is written.
+  sync
+}


### PR DESCRIPTION
This introduces a new `gather_metrics` script. The script leverages the new `promtool tsdb dump-openmetrics` command to extract metrics in OpenMetrics format.

The script accepts some arguments, run:
  $ ./collection-scripts/gather_metrics
for more details.

The dumpoed metrics can be imported into a Prometheus instance using:
  $ promtool tsdb create-blocks-from openmetrics
For more information, refer to https://prometheus.io/docs/prometheus/latest/command-line/promtool/#promtool-tsdb-create-blocks-from

Note that in some cases, using `increase()` or `{i}rate()` functions on the imported data may return negative or inaccurate results. This issue is under investigation and will be fixed upstream.

Recommendations:

- Import these metrics into a blank Prometheus instance.
- Ensure that the major version of the target Prometheus instance matches the major version of the dumped instance.
- If the involved metrics are old, consider adjusting the --storage.tsdb.retention.time setting in the host instance to prevent their removal (especially if the receiving Prometheus is to configured to scrape new targets)

---

the next step would be to add some out-of-the box metrics in `gather_monitoring`, see https://github.com/openshift/must-gather/pull/389