### PR TITLE
CNF-13837: gather_ppc: fallback option when NTO image not found

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -44,9 +44,13 @@ function ppc_nodes() {
   # NTO contains all the tools needed here
   NTO=$(oc get deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator -o jsonpath="{.spec.template.spec.containers[0].image}")
   if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to identify the container image with node tools."
-    echo "INFO: Node performance data collection will not contain node level data."
-    return
+    echo "INFO: Fallback to identify the container image from release info"
+    NTO=$(oc adm release info --image-for=cluster-node-tuning-operator)
+    if [ $? -ne 0 ]; then
+      echo "ERROR: Failed to identify the container image with node tools."
+      echo "INFO: Node performance data collection will not contain node level data."
+      return
+    fi
   fi
 
   echo "INFO: Image with low level tools to use: ${NTO}"


### PR DESCRIPTION
gather_ppc script is looking for NTO image, becuase it contains all the tools that needed.

On Hypershift platfrom, the control-plane components are located on a different cluster, so the script can't find NTO image since the controller is running on the remote (management) cluster.

This commit suggests to add a fallback method:
In case NTO deployment was not found, the script tries to get NTO image name from the release image.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>