### PR TITLE
MON-3108: fix(collection-scripts/monitoring_common.sh): set a default --sandbox-dir-root to 'promtool tsdb dump-openmetrics' for better UX

### DIFF
--- a/collection-scripts/monitoring_common.sh
+++ b/collection-scripts/monitoring_common.sh
@@ -21,7 +21,7 @@ metrics_get() {
   oc exec ${prometheus_pod} \
     -c prometheus \
     -n openshift-monitoring \
-    -- promtool tsdb dump-openmetrics /prometheus "$@" \
+    -- promtool tsdb dump-openmetrics /prometheus --sandbox-dir-root="/prometheus" "$@" \
        > "$METRICS_PATH/metrics.openmetrics" \
        2> "$METRICS_PATH/metrics.stderr"
 }


### PR DESCRIPTION
So users don't have to set it.

https://github.com/openshift/must-gather/pull/434 follow up.

This is a temporary fix until the upstream change is merged https://github.com/prometheus/prometheus/pull/14617 and shipped in OCP 

See https://prometheus.io/docs/prometheus/latest/command-line/promtool/#promtool-tsdb-dump-openmetrics for the flag doc.

