### PR TITLE
OCPBUGS-43052: Release-4.16 Network logs collection: skip unready nodes

### DIFF
--- a/collection-scripts/gather_network_logs_basics
+++ b/collection-scripts/gather_network_logs_basics
@@ -19,8 +19,9 @@ function gather_multus_data {
   done
 }
 
-CLUSTER_NODES="${@:-$(oc get node -l node-role.kubernetes.io/master -oname)}"
-/usr/bin/gather_multus_logs $CLUSTER_NODES
+READY_CONTROL_PLANE_NODES="${@:-$(oc get node -l node-role.kubernetes.io/control-plane -o json | jq -r '.items[] | select(.status.conditions[] | select(.type=="Ready" and .status=="True")).metadata.name')}"
+
+/usr/bin/gather_multus_logs $READY_CONTROL_PLANE_NODES
 
 function gather_ovn_kubernetes_data_interconnect_mode {
   echo "INFO: Gathering ovn-kubernetes DBs"


### PR DESCRIPTION
Previous to this change, debug pods will be launched to node that are unready and deployment will not complete.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
(cherry picked from commit 619862a66621e17258c5b1d3d5048970987f1eb5) (cherry picked from commit 5b8ba41a2c2a93b8d2efbce68bb0a96cee4d265e)