### PR TITLE
MCO-1418: Add collection for MOSC and MOSB

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -190,7 +190,7 @@ resources=()
 resources+=(performanceprofile)
 
 # machine/node resources
-resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses)
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses machineosconfigs machineosbuilds)
 
 echo "INFO: Waiting for node performance related collection to complete ..."
 


### PR DESCRIPTION
With the On Cluster Layering feature moving towards GA in in the MCO, we need to collect data on the two new kinds related to that. These are machineosconfigs and machineosbuilts.