### PR TITLE
OCPBUGS-44264: Collect all clustercsidriver resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -37,7 +37,7 @@ group_resources+=(nodes)
 named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
 
 # Storage Resources
-group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)
+group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents clustercsidrivers)
 all_ns_resources+=(csistoragecapacities)
 
 # Image-source Resources


### PR DESCRIPTION
ClusterCSIDriver objects are small, let's collect them all. We expect that there 4 ClusterCSIDriver instances in a cluster at max (e.g. Azure Disk, Azure File, SMB and SecretStore) and the instances are small.

Gathering these objects is important because we already gather Deployment, DaemonSets and other objects of CSI drivers by generic must-gather, and ClusterCSIDriver objects complement those info with managementState, cipherSuites, and various condition statuses for each CSI driver.