### PR TITLE
OCPBUGS-44857: Separate resources with comma to fix malformed inspect

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -50,7 +50,7 @@ group_resources+=(networks.operator.openshift.io)
 resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
 # Assisted Installer
-all_ns_resources+=(ns/assisted-installer)
+named_resources+=(ns/assisted-installer)
 
 # Leases
 all_ns_resources+=(leases)
@@ -78,7 +78,8 @@ group_resources_text=$(IFS=, ; echo "${filtered_group_resources[*]}")
 oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${group_resources_text}" &
 pids+=($!)
 
-oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}" --all-namespaces &
+all_ns_resources_text=$(IFS=, ; echo "${all_ns_resources[*]}")
+oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${all_ns_resources_text}" --all-namespaces &
 pids+=($!)
 
 # Gather Insights Operator Archives


### PR DESCRIPTION
Fix for: https://issues.redhat.com/browse/OCPBUGS-44857 

`oc adm inspect --all-namespaces` command was malformed, so its resources were never gathered.