### PR TITLE
OCPBUGS-52367: Fix collecting IPsec data for upgrade

### DIFF
--- a/collection-scripts/gather_network_logs_basics
+++ b/collection-scripts/gather_network_logs_basics
@@ -114,8 +114,9 @@ function gather_ovn_kubernetes_data {
     echo "INFO: LEGACY MODE"
     gather_ovn_kubernetes_data_legacy_mode
   fi
+  IPSEC_CONFIG=$(oc get networks.operator.openshift.io cluster -o jsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig}')
   IPSEC_MODE=$(oc get networks.operator.openshift.io cluster -o jsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig.mode}')
-  if [ "$IPSEC_MODE" != "" ] && [ "$IPSEC_MODE" != "Disabled" ]; then
+  if [ "$IPSEC_CONFIG" == "{}" ] || [ "$IPSEC_MODE" != "" ] && [ "$IPSEC_MODE" != "Disabled" ]; then
     gather_ovn_kubernetes_ipsec_data
   fi
   oc adm top pods -n openshift-ovn-kubernetes --containers > "${NETWORK_LOG_PATH}"/ovn_kubernetes_top_pods & PIDS+=($!)


### PR DESCRIPTION
After IPsec is upgraded from 4.14 into later versions, API option for IPsec in networks.operator.openshift.io cluster object continues to have {} in the ipsecConfig and may not be migrated to newer version containing IPsec mode option. This is supported in OCP for backward compatibility, so mg needs fixing to collect IPsec data when API configured with old option.