### PR TITLE
CORENET-5412: network: Gather OVN-Kubernetes CUDN CRs

### DIFF
--- a/collection-scripts/gather_network_logs_basics
+++ b/collection-scripts/gather_network_logs_basics
@@ -141,6 +141,7 @@ gather_scale_data
 
 if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
     oc adm inspect ${log_collection_args} --dest-dir must-gather egressips.k8s.ovn.org
+    oc adm inspect ${log_collection_args} --dest-dir must-gather clusteruserdefinednetworks.k8s.ovn.org
     oc adm inspect ${log_collection_args} --dest-dir must-gather adminnetworkpolicies.policy.networking.k8s.io
     oc adm inspect ${log_collection_args} --dest-dir must-gather baselineadminnetworkpolicies.policy.networking.k8s.io
     gather_ovn_kubernetes_data


### PR DESCRIPTION
The ClusterUserDefinedNetwork (CUDN) is cluster-scoped, installed by cluster-network-operator [1].

Creating CUDN CR result with a NetworkAttachmentDefinition (NAD) CR being created according to the CUDN CR 'spec.network', in each selected namespaces according to the CUDN CR 'spec.namespaceSelector'.

Collect CUDN CRs.

Having CUDN CRs collected enable troubleshooting OVN-Kubernetes user-defined networks in case of miss-configurations or env issues. The

[1] https://github.com/openshift/cluster-network-operator