### PR TITLE
MCO-1648: MCO-1649: Add `machineconfignodes` and `pinnedimagesets` to must-gather

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -190,7 +190,7 @@ resources=()
 resources+=(performanceprofile)
 
 # machine/node resources
-resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses machineosconfigs machineosbuilds machineconfigurations)
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses machineosconfigs machineosbuilds machineconfigurations machineconfignodes pinnedimagesets)
 
 echo "INFO: Waiting for node performance related collection to complete ..."
 


### PR DESCRIPTION
This adds the `MachineConfigNodes` and `PinnedImageSets` resources to must gathers.

**To test:**
1. Launch a 4.19 cluster with tech preview enabled.
```
launch 4.19.0-0.ci-2025-04-28-053740 aws,techpreview
```

2. Apply a PIS.
<details><summary>Example PIS</summary>
<pre>
apiVersion: machineconfiguration.openshift.io/v1
kind: PinnedImageSet
metadata:
  name: test-pinned
  labels:
    machineconfiguration.openshift.io/role: "worker"
spec:
  pinnedImages:
   - name: quay.io/openshift-release-dev/ocp-release@sha256:513cf1028aa1a021fa73d0601427a0fbcf6d212b88aaf9d76d4e4841a061e44e
   - name: quay.io/openshift-release-dev/ocp-release@sha256:61eae2d261e54d1b8a0e05f6b5326228b00468364563745eed88460af04f909b
</pre>
</details>

```
$ oc apply -f <pis-file>
```

3. Create the must-gather from the updated `gather_ppc` script.
```
./collection-scripts/gather_ppc
```

4. See the resources in the created must-gather.
```
must-gather
-- cluster-scoped-resources
---- machineconfiguration.openshift.io
...
------ machineconfignodes
-------- ip-10-0-0-9.ec2.internal.yaml
-------- ip-10-0-58-49.ec2.internal.yaml
-------- ip-10-0-7-211.ec2.internal.yaml
-------- ip-10-0-43-205.ec2.internal.yaml
-------- ip-10-0-66-94.ec2.internal.yaml
-------- ip-10-0-78-97.ec2.internal.yaml
...
------ pinnedimagesets
-------- test-pinned.yaml
```