### PR TITLE
OCPBUGS-66983: Fix race condition in gather_core_dumps pod name retrieval

### DIFF
--- a/collection-scripts/gather_core_dumps
+++ b/collection-scripts/gather_core_dumps
@@ -7,22 +7,44 @@ mkdir -p "${CORE_DUMP_PATH}"/
 function get_dump_off_node {
 	local debugPod=""
 
-	#Get debug pod's name
-	debugPod=$(oc debug --to-namespace="default" node/"$1" -o jsonpath='{.metadata.name}')
+	#Start Debug pod in background and capture output to get pod name
+	local tmpfile=$(mktemp)
+	oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' > "$tmpfile" 2>&1 &
 
-	#Start Debug pod force it to stay up until removed in "default" namespace
-	oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' >/dev/null 2>&1 &
+	#Wait for the debug pod to be created and extract its name with exponential backoff
+	local max_attempts=10  # Fewer attempts needed with exponential backoff
+	local attempt=0
+	local base_delay=0.1  # Starting delay in seconds
+	local max_delay=2.0   # Cap the maximum delay
 
-	#Mimic a normal oc call, i.e pause between two successive calls to allow pod to register
-	sleep 2
-	oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s
+	# Initial delay to allow pod creation to start
+	sleep 0.5
+
+	while [ -z "$debugPod" ] && [ $attempt -lt $max_attempts ]; do
+		debugPod=$(sed -n 's/.*pod\/\([^ ]*\).*/\1/p' "$tmpfile" 2>/dev/null | head -1)
+		if [ -z "$debugPod" ]; then
+			# Calculate exponential backoff: base_delay * 2^attempt
+			local delay=$(awk -v base="$base_delay" -v exponent="$attempt" -v max="$max_delay" \
+				'BEGIN {d = base * (2 ^ exponent); print (d > max) ? max : d}')
+			sleep "$delay"
+			attempt=$((attempt + 1))
+		fi
+	done
+	rm -f "$tmpfile"
+
+	#Wait for pod to be ready
+	if [ -n "$debugPod" ]; then
+		oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s > /dev/null 2>&1
+	fi
 
 	if [ -z "$debugPod" ]; then
 		echo "Debug pod for node ""$1"" never activated"
 	else
 		#Copy Core Dumps out of Nodes suppress Stdout
 		echo "Copying core dumps on node ""$1"""
-		oc cp --loglevel 1 -n "default" "$debugPod":/host/var/lib/systemd/coredump "${CORE_DUMP_PATH}"/"$1"_core_dump >/dev/null 2>&1 && PIDS+=($!)
+		if ! oc cp  --loglevel 1 -n "default" "$debugPod":/host/var/lib/systemd/coredump "${CORE_DUMP_PATH}"/"$1"_core_dump > /dev/null 2>&1; then
+			echo "Warning: Failed to copy core dumps from node $1"
+		fi
 
 		#clean up debug pod after we are done using them
 		oc delete pod "$debugPod" -n "default"
@@ -33,6 +55,7 @@ function gather_core_dump_data {
 	#Run coredump pull function on all nodes in parallel
 	for NODE in ${NODES}; do
 		get_dump_off_node "${NODE}" &
+		PIDS+=($!)
 	done
 }
 

--- a/collection-scripts/gather_core_dumps
+++ b/collection-scripts/gather_core_dumps
@@ -5,11 +5,17 @@ CORE_DUMP_PATH=${OUT:-"${BASE_COLLECTION_PATH}/node_core_dumps"}
 mkdir -p "${CORE_DUMP_PATH}"/
 
 function get_dump_off_node {
+	local node="$1"
 	local debugPod=""
+	local oc_debug_pid=""
+	local tmpfile
 
-	#Start Debug pod in background and capture output to get pod name
-	local tmpfile=$(mktemp)
-	oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' > "$tmpfile" 2>&1 &
+	tmpfile=$(mktemp)
+	trap 'rm -f "$tmpfile"' RETURN
+
+	# Start Debug pod in background and capture output to get pod name
+	oc debug --to-namespace="default" node/"$node" -- /bin/bash -c 'sleep 300' > "$tmpfile" 2>&1 &
+	oc_debug_pid=$!
 
 	#Wait for the debug pod to be created and extract its name with exponential backoff
 	local max_attempts=10  # Fewer attempts needed with exponential backoff
@@ -32,27 +38,33 @@ function get_dump_off_node {
 	done
 	rm -f "$tmpfile"
 
-	#Wait for pod to be ready
-	if [ -n "$debugPod" ]; then
-		oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s > /dev/null 2>&1
-	fi
-
 	if [ -z "$debugPod" ]; then
-		echo "Debug pod for node ""$1"" never activated"
-	else
-		#Copy Core Dumps out of Nodes suppress Stdout
-		echo "Copying core dumps on node ""$1"""
-		if ! oc cp  --loglevel 1 -n "default" "$debugPod":/host/var/lib/systemd/coredump "${CORE_DUMP_PATH}"/"$1"_core_dump > /dev/null 2>&1; then
-			echo "Warning: Failed to copy core dumps from node $1"
-		fi
-
-		#clean up debug pod after we are done using them
-		oc delete pod "$debugPod" -n "default"
+		kill "${oc_debug_pid}" 2>/dev/null
+		wait "${oc_debug_pid}" 2>/dev/null
+		echo "Debug pod for node $node never activated"
+		return
 	fi
+
+	if ! oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s > /dev/null 2>&1; then
+		echo "Warning: Debug pod $debugPod on node $node did not become Ready in time"
+		oc delete pod "$debugPod" -n "default" --wait=false > /dev/null 2>&1
+		kill "${oc_debug_pid}" 2>/dev/null
+		wait "${oc_debug_pid}" 2>/dev/null
+		return
+	fi
+
+	echo "Copying core dumps on node $node"
+	if ! oc cp --loglevel 1 -n "default" "$debugPod":/host/var/lib/systemd/coredump "${CORE_DUMP_PATH}/${node}_core_dump" > /dev/null 2>&1; then
+		echo "Warning: Failed to copy core dumps from node $node"
+	fi
+
+	oc delete pod "$debugPod" -n "default" --wait=false > /dev/null 2>&1
+	kill "${oc_debug_pid}" 2>/dev/null
+	wait "${oc_debug_pid}" 2>/dev/null
 }
 
 function gather_core_dump_data {
-	#Run coredump pull function on all nodes in parallel
+	# Run coredump pull function on all nodes in parallel
 	for NODE in ${NODES}; do
 		get_dump_off_node "${NODE}" &
 		PIDS+=($!)


### PR DESCRIPTION
As per the discussion with @anuragthehatter, raising this PR with his original changes in https://github.com/openshift/must-gather/pull/517.

Current logic found failed on one of prow CI run where node indeed had a core dump present but dump was not collected by oc adm must-gather -- gather_core_dumps command underneath a prow chain. It seems we may have missed core dumps collection since long time due to this race issue.

Failed logs on prod builds [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/72130/rehearse-72130-pull-ci-openshift-ovn-kubernetes-release-4.15-e2e-aws-ovn-fdp-qe/1996418222236110848/artifacts/e2e-aws-ovn-fdp-qe/gather-core-dump/build-log.txt)

Saw a race condition where dump was tried to be copied but debug pod was already removed.