### PR TITLE
no-jira: build(make): default podman flags for ART DNF wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,12 @@ ifeq ($(BUILDER), podman)
 # Use podman to build the must gather image
 # Please ensure you have podman installed on your machine for this
 IMAGE_BUILD_BUILDER := podman build
-# Clear all build default flags
-IMAGE_BUILD_DEFAULT_FLAGS :=
+# ART_DNF_WRAPPER_POLICY=skip: skip the ART image-build DNF wrapper so local podman
+# builds use ordinary dnf; the wrapper applies in CI/product pipelines, not here.
+IMAGE_BUILD_DEFAULT_FLAGS := --env ART_DNF_WRAPPER_POLICY=skip
 # Set authfile if the user passes another location for the authentication file
 ifneq ($(strip $(AUTH_FILE)),)
-IMAGE_BUILD_DEFAULT_FLAGS := --authfile=$(AUTH_FILE)
+IMAGE_BUILD_DEFAULT_FLAGS += --authfile=$(AUTH_FILE)
 endif
 endif
 


### PR DESCRIPTION
Local podman image builds were failing because the build expected dependencies only present in CI. 
Set `IMAGE_BUILD_DEFAULT_FLAGS` so podman passes `--env ART_DNF_WRAPPER_POLICY=skip` in the Makefile. When AUTH_FILE is set, --authfile is appended with `+=` so it does not override that default.