### PR TITLE
MG-241: Adding support for skipping rotated logs

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -31,23 +31,17 @@ get_log_collection_args() {
 		log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
 	fi
 
-	# Set in this shell; gather / gather_vsphere source this file and call
-	# get_log_collection_args before oc adm inspect — no export needed.
-	# REDUCE_LOGS: unset = default (--rotated-pod-logs). If set, only skip_rotated is allowed.
-	local rl="${REDUCE_LOGS:-}"
-	rl="${rl#"${rl%%[![:space:]]*}"}"
-	rl="${rl%"${rl##*[![:space:]]}"}"
 
+	# REDUCE_LOGS: unset = default (--rotated-pod-logs). If set, only skip_rotated_logs is allowed.
 	rotated_pod_logs_arg="--rotated-pod-logs"
 
-	if [ -n "$rl" ]; then
-		case "$rl" in
-		skip_rotated_logs | SKIP_ROTATED_LOGS)
+	if [ -n "${REDUCE_LOGS:-}" ]; then
+		case "${REDUCE_LOGS}" in
+		skip_rotated_logs)
 			rotated_pod_logs_arg=""
-			echo "DEBUG: REDUCE_LOGS set to skip_rotated_logs"
 			;;
 		*)
-			echo "ERROR: REDUCE_LOGS must be unset or skip_rotated_logs (got: [${rl}])." >&2
+			echo "ERROR: REDUCE_LOGS must be unset or skip_rotated_logs (got: [${REDUCE_LOGS}])." >&2
 			exit 1
 			;;
 		esac

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -31,6 +31,28 @@ get_log_collection_args() {
 		log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
 	fi
 
+	# Set in this shell; gather / gather_vsphere source this file and call
+	# get_log_collection_args before oc adm inspect — no export needed.
+	# REDUCE_LOGS: unset = default (--rotated-pod-logs). If set, only skip_rotated is allowed.
+	local rl="${REDUCE_LOGS:-}"
+	rl="${rl#"${rl%%[![:space:]]*}"}"
+	rl="${rl%"${rl##*[![:space:]]}"}"
+
+	rotated_pod_logs_arg="--rotated-pod-logs"
+
+	if [ -n "$rl" ]; then
+		case "$rl" in
+		skip_rotated_logs | SKIP_ROTATED_LOGS)
+			rotated_pod_logs_arg=""
+			echo "DEBUG: REDUCE_LOGS set to skip_rotated_logs"
+			;;
+		*)
+			echo "ERROR: REDUCE_LOGS must be unset or skip_rotated_logs (got: [${rl}])." >&2
+			exit 1
+			;;
+		esac
+	fi
+
 	# oc adm node-logs `--since` parameter is not the same as oc adm inspect `--since`.
 	# it takes a simplified duration in the form of '(+|-)[0-9]+(s|m|h|d)' or
 	# an ISO formatted time. since MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -63,7 +63,7 @@ group_resources+=(clusterresourcequotas.quota.openshift.io)
 
 # Run the Collection of Resources using inspect
 # running across all-namespaces for the few "Autoscaler" resources.
-oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${named_resources[@]}" &
+oc adm inspect ${log_collection_args} --dest-dir must-gather ${rotated_pod_logs_arg} "${named_resources[@]}" &
 pids+=($!)
 
 filtered_group_resources=()
@@ -77,14 +77,14 @@ group_resources_text=$(
 	IFS=,
 	echo "${filtered_group_resources[*]}"
 )
-oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${group_resources_text}" &
+oc adm inspect ${log_collection_args} --dest-dir must-gather ${rotated_pod_logs_arg} "${group_resources_text}" &
 pids+=($!)
 
 all_ns_resources_text=$(
 	IFS=,
 	echo "${all_ns_resources[*]}"
 )
-oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${all_ns_resources_text}" --all-namespaces &
+oc adm inspect ${log_collection_args} --dest-dir must-gather ${rotated_pod_logs_arg} "${all_ns_resources_text}" --all-namespaces &
 pids+=($!)
 
 # Gather Insights Operator Archives

--- a/collection-scripts/gather_vsphere
+++ b/collection-scripts/gather_vsphere
@@ -12,8 +12,8 @@ if [ -z "$CSIDRIVER" ]; then
 fi
 
 echo "INFO: Collecting vSphere CSI driver CRDs"
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" --rotated-pod-logs csinodetopologies.cns.vmware.com,cnsvspherevolumemigrations.cns.vmware.com
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" --rotated-pod-logs --all-namespaces cnsvolumeoperationrequests.cns.vmware.com
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" ${rotated_pod_logs_arg} csinodetopologies.cns.vmware.com,cnsvspherevolumemigrations.cns.vmware.com
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" ${rotated_pod_logs_arg} --all-namespaces cnsvolumeoperationrequests.cns.vmware.com
 
 echo "INFO: Collecting vSphere CSI driver CRDs complete"
 

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -109,9 +109,9 @@ load test_helper
 	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
 }
 
-@test "get_log_collection_args skips rotated pod logs when REDUCE_LOGS is skip_rotated" {
+@test "get_log_collection_args skips rotated pod logs when REDUCE_LOGS is skip_rotated_logs" {
 	run bash -c "
-		export REDUCE_LOGS='skip_rotated'
+		export REDUCE_LOGS='skip_rotated_logs'
 		source \"$SCRIPT_DIR/common.sh\"
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
@@ -123,14 +123,14 @@ load test_helper
 
 @test "get_log_collection_args fails when REDUCE_LOGS is comma-separated" {
 	run bash -c "
-		export REDUCE_LOGS='skip_rotated,other'
+		export REDUCE_LOGS='skip_rotated_logs,other'
 		source \"$SCRIPT_DIR/common.sh\"
 		get_log_collection_args
 	"
 
 	assert_failure
 	assert_output --partial "ERROR"
-	assert_output --partial "skip_rotated,other"
+	assert_output --partial "skip_rotated_logs,other"
 }
 
 @test "get_log_collection_args fails when REDUCE_LOGS is unknown" {
@@ -142,7 +142,7 @@ load test_helper
 
 	assert_failure
 	assert_output --partial "ERROR"
-	assert_output --partial "skip_rotated"
+	assert_output --partial "skip_rotated_logs"
 }
 
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -97,6 +97,54 @@ load test_helper
 	assert_output --partial "log_collection_args=[]"
 }
 
+@test "get_log_collection_args enables rotated pod logs by default" {
+	run bash -c "
+		unset REDUCE_LOGS
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
+}
+
+@test "get_log_collection_args skips rotated pod logs when REDUCE_LOGS is skip_rotated" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+}
+
+@test "get_log_collection_args fails when REDUCE_LOGS is comma-separated" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated,other'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+	"
+
+	assert_failure
+	assert_output --partial "ERROR"
+	assert_output --partial "skip_rotated,other"
+}
+
+@test "get_log_collection_args fails when REDUCE_LOGS is unknown" {
+	run bash -c "
+		export REDUCE_LOGS='invalid'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+	"
+
+	assert_failure
+	assert_output --partial "ERROR"
+	assert_output --partial "skip_rotated"
+}
+
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {
 	run bash -c "
 		export MUST_GATHER_SINCE='8h'


### PR DESCRIPTION
This PR addresses https://redhat.atlassian.net/browse/MG-241 .

Summary
This change lets the default must-gather collection omit oc adm inspect --rotated-pod-logs when the user explicitly requests it, without adding new flags to oc adm must-gather. Control is via the REDUCE_LOGS environment variable on the gather process (shell assignment before /usr/bin/gather, same pattern as other gather scripts).

**Behavior**
REDUCE_LOGS unset or empty (after trimming leading/trailing whitespace): unchanged behavior — --rotated-pod-logs is passed to oc adm inspect as today.
REDUCE_LOGS=skip_rotated_logs (or SKIP_ROTATED_LOGS): --rotated-pod-logs is not passed (rotated pod logs skipped for those inspect invocations).
Any other non-empty value: ERROR on stderr and exit 1 — gather stops (invalid values, comma-separated strings, typos, etc.).

**Implementation** notes
Logic lives in get_log_collection_args() in collection-scripts/common.sh, which sets rotated_pod_logs_arg (either --rotated-pod-logs or empty).
gather and gather_vsphere use ${rotated_pod_logs_arg} on their oc adm inspect lines instead of hardcoding --rotated-pod-logs.


**Usage**
`oc adm must-gather -- REDUCE_LOGS=skip_rotated_logs /usr/bin/gather`


**Tests**
tests/common.bats: covers defaults, successful skip, and failure paths for invalid / comma-separated REDUCE_LOGS.
