### PR TITLE
MG-246: remove redundant oc inspect command and unused resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -166,7 +166,7 @@ pids+=($!)
 pids+=($!)
 
 # Gather Performance profile information (nodes already inspected above via group_resources)
-MUST_GATHER_NODES_INSPECTED=1 /usr/bin/gather_ppc &
+MUST_GATHER_NODES_INSPECTED=true /usr/bin/gather_ppc &
 pids+=($!)
 
 # Gather OSUS information

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -46,8 +46,6 @@ group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)
 
-# NodeNetworkState
-resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
 # Assisted Installer
 named_resources+=(ns/assisted-installer)
@@ -167,8 +165,8 @@ pids+=($!)
 /usr/bin/gather_vsphere &
 pids+=($!)
 
-# Gather Performance profile information
-/usr/bin/gather_ppc &
+# Gather Performance profile information (nodes already inspected above via group_resources)
+MUST_GATHER_NODES_INSPECTED=1 /usr/bin/gather_ppc &
 pids+=($!)
 
 # Gather OSUS information

--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -196,9 +196,13 @@ resources=()
 # performance operator profiles
 resources+=(performanceprofile)
 
-# machine/node resources
-resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses machineosconfigs machineosbuilds machineconfigurations machineconfignodes pinnedimagesets)
+# Include 'nodes' only when running standalone (main gather already inspects nodes via group_resources)
+if [ -z "${MUST_GATHER_NODES_INSPECTED:-}" ]; then
+	resources+=(nodes)
+fi
 
+# machine/node resources
+resources+=(machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses machineosconfigs machineosbuilds machineconfigurations machineconfignodes pinnedimagesets)
 echo "INFO: Waiting for node performance related collection to complete ..."
 
 # run the collection of resources using must-gather


### PR DESCRIPTION
1. Removed the redundant `oc adm inspect nodes` command. It was being executed in both the `gather` and `gather_ppc` scripts, which increases execution time on clusters with a large number of nodes.
2. Cleaned up the `gather` script by removing the unused `resources` array, as those resources are already collected by the `gather_nmstate` script.