### PR TITLE
MG-247: collect imagedigestmirrorsets and imagetagmirrorset resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -41,7 +41,7 @@ group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers 
 all_ns_resources+=(csistoragecapacities)
 
 # Image-source Resources
-group_resources+=(imagecontentsourcepolicies.operator.openshift.io imagedigestmirrorsets.config.openshift.io imagetagmirrorset.config.openshift.io)
+group_resources+=(imagecontentsourcepolicies.operator.openshift.io imagedigestmirrorsets.config.openshift.io imagetagmirrorsets.config.openshift.io)
 
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -41,7 +41,7 @@ group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers 
 all_ns_resources+=(csistoragecapacities)
 
 # Image-source Resources
-group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
+group_resources+=(imagecontentsourcepolicies.operator.openshift.io imagedigestmirrorsets.config.openshift.io imagetagmirrorset.config.openshift.io)
 
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)


### PR DESCRIPTION
This PR aims to include ImageDigestMirrorSet and ImageTagMirrorSet resources which are currently not included in the data collection. 

Using ImageContentSourcePolicy is a [deprecated feature](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/images/image-configuration-classic#images-configuration-registry-mirror_image-configuration) which is being replaced with ImageDigestMirrorSet and ImageTagMirrorSet