### PR TITLE
refactor: extract shared CRD inspection helpers into common.sh

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -65,3 +65,21 @@ get_log_collection_args() {
 		node_log_collection_args=--since="${iso_time}"
 	fi
 }
+
+inspect_crds_namespaced() {
+	local ns="$1"
+	shift
+	# shellcheck disable=SC2086
+	oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n "${ns}" "$@"
+}
+
+inspect_crds_cluster() {
+	# shellcheck disable=SC2086
+	oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "$@"
+}
+
+inspect_operator_ns() {
+	local ns="$1"
+	# shellcheck disable=SC2086
+	oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${ns}"
+}

--- a/collection-scripts/gather_frrk8s
+++ b/collection-scripts/gather_frrk8s
@@ -7,15 +7,6 @@ get_log_collection_args
 FRRK8S_NS="openshift-frr-k8s"
 FRRK8S_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${FRRK8S_NS}/pods"
 
-function get_frrk8s_crs() {
-	declare -a FRRK8S_CRDS=("frrconfiguration" "frrnodestate")
-
-	for CRD in "${FRRK8S_CRDS[@]}"; do
-		# shellcheck disable=SC2086
-		oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${FRRK8S_NS} "${CRD}"
-	done
-}
-
 function gather_frr_logs() {
 	declare -a FILES_TO_GATHER=("frr.conf" "daemons" "vtysh.conf")
 	declare -a COMMANDS=("show running-config" "show bgp ipv4" "show bgp ipv6" "show bgp neighbor" "show bfd peer")
@@ -37,9 +28,8 @@ if ! oc get ns "${FRRK8S_NS}" &>/dev/null; then
 	exit
 fi
 
-# shellcheck disable=SC2086
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${FRRK8S_NS}"
-get_frrk8s_crs
+inspect_operator_ns "${FRRK8S_NS}"
+inspect_crds_namespaced "${FRRK8S_NS}" frrconfiguration frrnodestate
 
 if [ $# -gt 0 ]; then
 	FRR_PODS=("$@")

--- a/collection-scripts/gather_ingress_node_firewall
+++ b/collection-scripts/gather_ingress_node_firewall
@@ -6,28 +6,9 @@ BASE_COLLECTION_PATH="must-gather"
 get_operator_ns "ingress-node-firewall"
 get_log_collection_args
 
-function get_ingress_node_firewall_namespaced_crs() {
-	declare -a INGRESS_NODE_FIREWALL_NAMESPACED_CRDS=("ingressnodefirewallconfigs" "ingressnodefirewallnodestates")
-
-	for CRD in "${INGRESS_NODE_FIREWALL_NAMESPACED_CRDS[@]}"; do
-		# shellcheck disable=SC2086
-		oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n "${operator_ns}" "${CRD}"
-	done
-}
-
-function get_ingress_node_firewall_cluster_crs() {
-	declare -a INGRESS_NODE_FIREWALL_CLUSTER_CRDS=("ingressnodefirewalls")
-
-	for CRD in "${INGRESS_NODE_FIREWALL_CLUSTER_CRDS[@]}"; do
-		# shellcheck disable=SC2086
-		oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
-	done
-}
-
-# shellcheck disable=SC2086
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
-get_ingress_node_firewall_namespaced_crs
-get_ingress_node_firewall_cluster_crs
+inspect_operator_ns "${operator_ns}"
+inspect_crds_namespaced "${operator_ns}" ingressnodefirewallconfigs ingressnodefirewallnodestates
+inspect_crds_cluster ingressnodefirewalls
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_metallb
+++ b/collection-scripts/gather_metallb
@@ -8,19 +8,8 @@ get_log_collection_args
 # shellcheck disable=SC2034
 METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}/pods"
 
-function get_metallb_crs() {
-	declare -a METALLB_CRDS=("bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities")
-
-	for CRD in "${METALLB_CRDS[@]}"; do
-		# shellcheck disable=SC2086
-		oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n "${operator_ns}" "${CRD}"
-	done
-}
-
-# shellcheck disable=SC2086
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
-
-get_metallb_crs
+inspect_operator_ns "${operator_ns}"
+inspect_crds_namespaced "${operator_ns}" bgppeers bfdprofiles bgpAdvertisements ipaddresspools l2advertisements communities
 
 if ! oc get metallb metallb -n "${operator_ns}" >/dev/null 2>&1; then
 	echo "metallb not started"

--- a/collection-scripts/gather_nfd
+++ b/collection-scripts/gather_nfd
@@ -5,17 +5,9 @@ BASE_COLLECTION_PATH="must-gather"
 get_operator_ns "nfd"
 get_log_collection_args
 
-function get_nfd_crs() {
-    declare -a NFD_CRDS=("nodefeaturediscoveries" "nodefeaturegroups" "nodefeaturerules" "nodefeatures")
-
-    for CRD in "${NFD_CRDS[@]}"; do
-        echo "INFO: Collecting NFD Data for ${CRD} in namespace ${operator_ns}"
-        oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}" -n "${operator_ns}"
-    done
-}
-
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
-get_nfd_crs
+echo "INFO: Collecting NFD Data in namespace ${operator_ns}"
+inspect_operator_ns "${operator_ns}"
+inspect_crds_namespaced "${operator_ns}" nodefeaturediscoveries nodefeaturegroups nodefeaturerules nodefeatures
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_nmstate
+++ b/collection-scripts/gather_nmstate
@@ -6,18 +6,8 @@ BASE_COLLECTION_PATH="must-gather"
 get_operator_ns "kubernetes-nmstate-operator"
 get_log_collection_args
 
-function get_nmstate_crs() {
-	declare -a NMSTATE_CRDS=("nmstates" "nodenetworkconfigurationenactments" "nodenetworkconfigurationpolicies" "nodenetworkstates")
-
-	for CRD in "${NMSTATE_CRDS[@]}"; do
-		# shellcheck disable=SC2086
-		oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
-	done
-}
-
-# shellcheck disable=SC2086
-oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
-get_nmstate_crs
+inspect_operator_ns "${operator_ns}"
+inspect_crds_cluster nmstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies nodenetworkstates
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync


### PR DESCRIPTION
## Summary

- Extracts three shared helpers into `common.sh`: `inspect_crds_namespaced`, `inspect_crds_cluster`, and `inspect_operator_ns`
- Refactors 5 operator-collector scripts (metallb, nfd, nmstate, ingress_node_firewall, frrk8s) to use them, removing per-script CRD loop functions
- Passes all CRDs to a single `oc adm inspect` invocation instead of looping, reducing process spawns from N to 1 per call

Net result: +30 / -70 lines across 6 files. No behavioral changes.

Jira: [CNF-23507](https://redhat.atlassian.net/browse/CNF-23507)

## Test plan

- [ ] Verify `make lint` passes (pre-existing gather_nfd warnings are unrelated)
- [ ] Verify `make test` passes (pre-existing BATS failures are unrelated)
- [ ] Confirm no refactored scripts still define their own CRD inspection loops: `grep -n 'for CRD in' collection-scripts/gather_{metallb,nfd,nmstate,ingress_node_firewall,frrk8s}` returns empty
- [ ] Run must-gather on a cluster with metallb/nfd/nmstate/ingress-node-firewall/frrk8s operators and verify CRDs are collected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined diagnostic collection scripts by consolidating common inspection operations into centralized helper functions, reducing code duplication and improving consistency across multiple collection modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->