### PR TITLE
fix: run perf-node-gather-daemonset container as root

### DIFF
--- a/collection-scripts/gather_ppc
+++ b/collection-scripts/gather_ppc
@@ -95,6 +95,8 @@ spec:
         image: ${NTO}
         command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
## Problem

The `node-probe` container in `perf-node-gather-daemonset` mounts `/var/lib/kubelet/pod-resources` via `hostPath` and connects to `kubelet.sock` to collect pod resource metrics (CPU/memory allocations per pod). The socket is owned by root and is not group- or world-readable, so a non-root container process receives:

```
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /host/podresources/kubelet.sock: connect: permission denied"
```

This error is non-fatal — the gather continues — but pod resource metrics are silently missing from the must-gather bundle.

## Fix

Add `securityContext: runAsUser: 0` to the `node-probe` container so it runs as UID 0 and can open the kubelet socket.

## Testing

Tested on a 5-node OCP cluster using the must-gather-operator. Before this fix all 5 daemonset pods logged the `kubelet.sock: connect: permission denied` error. After this fix the gather runs clean with no socket errors and pod resource data is present in the bundle.