### PR TITLE
OCPBUGS-86136: Add InternalReleaseImage to gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -48,6 +48,9 @@ group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
 # OS Image Stream Resources
 group_resources+=(osimagestreams.machineconfiguration.openshift.io)
 
+# Internal Release Image Resources
+group_resources+=(internalreleaseimages.machineconfiguration.openshift.io)
+
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)
 


### PR DESCRIPTION
Add the InternalReleaseImage CR to the list of cluster-scoped resources gathered by the tool.

Since an existing check verifies the resource exists on the cluster before attempting to inspect it, it won't cause errors on clusters where the CR isn't available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cluster inspection to gather additional resource types during collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->