### PR TITLE
MG-233: compress service and window node logs

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -34,9 +34,9 @@ get_log_collection_args() {
 
 	# REDUCE_LOGS: unset = defaults. Comma or space separated list of:
 	#   skip_rotated_logs     - omit --rotated-pod-logs from oc adm inspect
-	#   compress_service_logs - gzip host service logs (see gather_service_logs_util)
+	#   compress_service_logs - gzip host service logs (see gather_service_logs_util)	
 	# shellcheck disable=SC2034
-	rotated_pod_logs_arg="--rotated-pod-logs"
+	rotated_pod_logs_arg="--rotated-pod-logs"	
 	# shellcheck disable=SC2034
 	compress_service_logs=""
 
@@ -50,7 +50,7 @@ get_log_collection_args() {
 				rotated_pod_logs_arg=""
 				;;
 			compress_service_logs)
-				compress_service_logs=1
+				compress_service_logs=true
 				;;
 			"")
 				;;

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -32,19 +32,34 @@ get_log_collection_args() {
 	fi
 
 
-	# REDUCE_LOGS: unset = default (--rotated-pod-logs). If set, only skip_rotated_logs is allowed.
+	# REDUCE_LOGS: unset = defaults. Comma or space separated list of:
+	#   skip_rotated_logs     - omit --rotated-pod-logs from oc adm inspect
+	#   compress_service_logs - gzip host service logs (see gather_service_logs_util)
+	# shellcheck disable=SC2034
 	rotated_pod_logs_arg="--rotated-pod-logs"
+	# shellcheck disable=SC2034
+	compress_service_logs=""
 
 	if [ -n "${REDUCE_LOGS:-}" ]; then
-		case "${REDUCE_LOGS}" in
-		skip_rotated_logs)
-			rotated_pod_logs_arg=""
-			;;
-		*)
-			echo "ERROR: REDUCE_LOGS must be unset or skip_rotated_logs (got: [${REDUCE_LOGS}])." >&2
-			exit 1
-			;;
-		esac
+		# Normalize commas to spaces, then validate each option.
+		# Intentional word-splitting of comma/space separated options.
+		# shellcheck disable=SC2086
+		for reduce_logs_option in ${REDUCE_LOGS//,/ }; do
+			case "${reduce_logs_option}" in
+			skip_rotated_logs)
+				rotated_pod_logs_arg=""
+				;;
+			compress_service_logs)
+				compress_service_logs=1
+				;;
+			"")
+				;;
+			*)
+				echo "ERROR: REDUCE_LOGS unknown value '${reduce_logs_option}'. Allowed: skip_rotated_logs, compress_service_logs (got: [${REDUCE_LOGS}])." >&2
+				exit 1
+				;;
+			esac
+		done
 	fi
 
 	# oc adm node-logs `--since` parameter is not the same as oc adm inspect `--since`.

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -18,9 +18,6 @@ function get_operator_ns() {
 	fi
 }
 
-# Sets globals for callers: log_collection_args, node_log_collection_args,
-# rotated_pod_logs_arg, compress_service_logs. SC2034: assigned here, read elsewhere.
-# shellcheck disable=SC2034
 get_log_collection_args() {
 	# validation of MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME is done by the
 	# caller (oc adm must-gather) so it's safe to use the values as they are.
@@ -79,4 +76,8 @@ get_log_collection_args() {
 		iso_time=$(echo "${MUST_GATHER_SINCE_TIME}" | sed 's/T/ /; s/Z//')
 		node_log_collection_args=--since="${iso_time}"
 	fi
+
+	# Export globals used by gather_* scripts that source this file (also satisfies ShellCheck SC2034):
+	# log_collection_args, node_log_collection_args, rotated_pod_logs_arg, compress_service_logs.
+	export log_collection_args node_log_collection_args rotated_pod_logs_arg compress_service_logs
 }

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -18,6 +18,9 @@ function get_operator_ns() {
 	fi
 }
 
+# Sets globals for callers: log_collection_args, node_log_collection_args,
+# rotated_pod_logs_arg, compress_service_logs. SC2034: assigned here, read elsewhere.
+# shellcheck disable=SC2034
 get_log_collection_args() {
 	# validation of MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME is done by the
 	# caller (oc adm must-gather) so it's safe to use the values as they are.
@@ -27,17 +30,15 @@ get_log_collection_args() {
 		log_collection_args=--since="${MUST_GATHER_SINCE}"
 	fi
 	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
-		# shellcheck disable=SC2034
 		log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
 	fi
 
 
 	# REDUCE_LOGS: unset = defaults. Comma or space separated list of:
 	#   skip_rotated_logs     - omit --rotated-pod-logs from oc adm inspect
-	#   compress_service_logs - gzip host service logs (see gather_service_logs_util)	
-	# shellcheck disable=SC2034
-	rotated_pod_logs_arg="--rotated-pod-logs"	
-	# shellcheck disable=SC2034
+	#   compress_service_logs - gzip host service / Windows node logs (see gather_service_logs_util, gather_windows_node_logs)
+
+	rotated_pod_logs_arg="--rotated-pod-logs"
 	compress_service_logs=""
 
 	if [ -n "${REDUCE_LOGS:-}" ]; then
@@ -74,7 +75,6 @@ get_log_collection_args() {
 		since=$(echo "${MUST_GATHER_SINCE:-}" | sed 's/\([0-9]*[dhms]\).*/\1/')
 		node_log_collection_args=--since="-${since}"
 	fi
-	# shellcheck disable=SC2034
 	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
 		iso_time=$(echo "${MUST_GATHER_SINCE_TIME}" | sed 's/T/ /; s/Z//')
 		node_log_collection_args=--since="${iso_time}"

--- a/collection-scripts/gather_service_logs_util
+++ b/collection-scripts/gather_service_logs_util
@@ -22,13 +22,21 @@ function collect_service_logs {
 	fi
 
 	mkdir -p "${DIR_PATH}"
+	# In CI (OPENSHIFT_CI/ARTIFACTS_DIR) skip gzip for easier inspection of artifacts
+	if [[ -n "${OPENSHIFT_CI:-}" || -n "${ARTIFACTS_DIR:-}" ]]; then
+		LOG_SUFFIX=".log"
+		LOG_PIPE="cat"
+	else
+		LOG_SUFFIX=".log.gz"
+		LOG_PIPE="gzip"
+	fi
 	for service in "${@}"; do
 		echo "INFO: Collecting host service logs for $service"
 		if [[ ${selector} =~ '--role=' ]]; then
-			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -l kubernetes.io/os=linux -u "${service}" >"${DIR_PATH}/${service}_service.log" &
+			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -l kubernetes.io/os=linux -u "${service}" | ${LOG_PIPE} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
 			PIDS+=($!)
 		else
-			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -u "${service}" >"${DIR_PATH}/${service}_service.log" &
+			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -u "${service}" | ${LOG_PIPE} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
 			PIDS+=($!)
 		fi
 	done

--- a/collection-scripts/gather_service_logs_util
+++ b/collection-scripts/gather_service_logs_util
@@ -22,13 +22,14 @@ function collect_service_logs {
 	fi
 
 	mkdir -p "${DIR_PATH}"
-	# In CI (OPENSHIFT_CI/ARTIFACTS_DIR) skip gzip for easier inspection of artifacts
-	if [[ -n "${OPENSHIFT_CI:-}" || -n "${ARTIFACTS_DIR:-}" ]]; then
-		LOG_SUFFIX=".log"
-		LOG_PIPE="cat"
-	else
+	# Default: uncompressed .log for compatibility with existing tooling.
+	# Opt in via REDUCE_LOGS=compress_service_logs (parsed by get_log_collection_args).
+	if [[ -n "${compress_service_logs:-}" ]]; then
 		LOG_SUFFIX=".log.gz"
 		LOG_PIPE="gzip"
+	else
+		LOG_SUFFIX=".log"
+		LOG_PIPE="cat"
 	fi
 	for service in "${@}"; do
 		echo "INFO: Collecting host service logs for $service"

--- a/collection-scripts/gather_service_logs_util
+++ b/collection-scripts/gather_service_logs_util
@@ -24,12 +24,11 @@ function collect_service_logs {
 	mkdir -p "${DIR_PATH}"
 	# Default: uncompressed .log for compatibility with existing tooling.
 	# Opt in via REDUCE_LOGS=compress_service_logs (parsed by get_log_collection_args).
-	if [[ -n "${compress_service_logs:-}" ]]; then
+	LOG_SUFFIX=".log"
+	LOG_PIPE="cat"
+	if [[ "${compress_service_logs:-}" == "true" ]]; then
 		LOG_SUFFIX=".log.gz"
 		LOG_PIPE="gzip"
-	else
-		LOG_SUFFIX=".log"
-		LOG_PIPE="cat"
 	fi
 	for service in "${@}"; do
 		echo "INFO: Collecting host service logs for $service"

--- a/collection-scripts/gather_service_logs_util
+++ b/collection-scripts/gather_service_logs_util
@@ -25,18 +25,18 @@ function collect_service_logs {
 	# Default: uncompressed .log for compatibility with existing tooling.
 	# Opt in via REDUCE_LOGS=compress_service_logs (parsed by get_log_collection_args).
 	LOG_SUFFIX=".log"
-	LOG_PIPE="cat"
+	LOG_OUTPUT_CMD="cat"
 	if [[ "${compress_service_logs:-}" == "true" ]]; then
 		LOG_SUFFIX=".log.gz"
-		LOG_PIPE="gzip"
+		LOG_OUTPUT_CMD="gzip"
 	fi
 	for service in "${@}"; do
 		echo "INFO: Collecting host service logs for $service"
 		if [[ ${selector} =~ '--role=' ]]; then
-			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -l kubernetes.io/os=linux -u "${service}" | ${LOG_PIPE} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
+			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -l kubernetes.io/os=linux -u "${service}" | ${LOG_OUTPUT_CMD} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
 			PIDS+=($!)
 		else
-			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -u "${service}" | ${LOG_PIPE} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
+			oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" "${selector}" -u "${service}" | ${LOG_OUTPUT_CMD} >"${DIR_PATH}/${service}_service${LOG_SUFFIX}" &
 			PIDS+=($!)
 		fi
 	done

--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -22,11 +22,19 @@ if [ -z "$WIN_NODES" ]; then
 fi
 
 PIDS=()
+# Default: uncompressed for compatibility with existing tooling.
+# Opt in via REDUCE_LOGS=compress_service_logs (parsed by get_log_collection_args).
+LOG_SUFFIX=""
+LOG_OUTPUT_CMD="cat"
+if [[ "${compress_service_logs:-}" == "true" ]]; then
+	LOG_SUFFIX=".gz"
+	LOG_OUTPUT_CMD="gzip"
+fi
 echo INFO: Collecting logs for all Windows nodes
 for log in "${LOGS[@]}"; do
 	LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname "$log")
 	mkdir -p "${LOG_FILE_DIR}"
-	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" | gzip >"${LOG_FILE_DIR}/$(basename "$log").gz" &
+	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" | ${LOG_OUTPUT_CMD} >"${LOG_FILE_DIR}/$(basename "$log")${LOG_SUFFIX}" &
 	PIDS+=($!)
 done
 wait "${PIDS[@]}"

--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -22,21 +22,12 @@ if [ -z "$WIN_NODES" ]; then
 fi
 
 PIDS=()
-# In CI (OPENSHIFT_CI/ARTIFACTS_DIR) skip gzip for easier inspection of artifacts
-if [[ -n "${OPENSHIFT_CI:-}" || -n "${ARTIFACTS_DIR:-}" ]]; then
-	WIN_LOG_SUFFIX=""
-	WIN_LOG_PIPE="cat"
-else
-	WIN_LOG_SUFFIX=".gz"
-	WIN_LOG_PIPE="gzip"
-fi
-
 WINDOWS_NODE_LOGS_START=$(date +%s)
 echo INFO: Collecting logs for all Windows nodes
 for log in "${LOGS[@]}"; do
 	LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname "$log")
 	mkdir -p "${LOG_FILE_DIR}"
-	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" | ${WIN_LOG_PIPE} >"${LOG_FILE_DIR}/$(basename "$log")${WIN_LOG_SUFFIX}" &
+	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" | gzip >"${LOG_FILE_DIR}/$(basename "$log").gz" &
 	PIDS+=($!)
 done
 wait "${PIDS[@]}"

--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -22,7 +22,6 @@ if [ -z "$WIN_NODES" ]; then
 fi
 
 PIDS=()
-WINDOWS_NODE_LOGS_START=$(date +%s)
 echo INFO: Collecting logs for all Windows nodes
 for log in "${LOGS[@]}"; do
 	LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname "$log")
@@ -31,8 +30,6 @@ for log in "${LOGS[@]}"; do
 	PIDS+=($!)
 done
 wait "${PIDS[@]}"
-WINDOWS_NODE_LOGS_END=$(date +%s)
-echo "INFO: Windows node log collection completed in $((WINDOWS_NODE_LOGS_END - WINDOWS_NODE_LOGS_START)) seconds"
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -22,14 +22,26 @@ if [ -z "$WIN_NODES" ]; then
 fi
 
 PIDS=()
+# In CI (OPENSHIFT_CI/ARTIFACTS_DIR) skip gzip for easier inspection of artifacts
+if [[ -n "${OPENSHIFT_CI:-}" || -n "${ARTIFACTS_DIR:-}" ]]; then
+	WIN_LOG_SUFFIX=""
+	WIN_LOG_PIPE="cat"
+else
+	WIN_LOG_SUFFIX=".gz"
+	WIN_LOG_PIPE="gzip"
+fi
+
+WINDOWS_NODE_LOGS_START=$(date +%s)
 echo INFO: Collecting logs for all Windows nodes
 for log in "${LOGS[@]}"; do
 	LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname "$log")
 	mkdir -p "${LOG_FILE_DIR}"
-	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" >"${LOG_FILE_DIR}/$(basename "$log")" &
+	/usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path="$log" | ${WIN_LOG_PIPE} >"${LOG_FILE_DIR}/$(basename "$log")${WIN_LOG_SUFFIX}" &
 	PIDS+=($!)
 done
 wait "${PIDS[@]}"
+WINDOWS_NODE_LOGS_END=$(date +%s)
+echo "INFO: Windows node log collection completed in $((WINDOWS_NODE_LOGS_END - WINDOWS_NODE_LOGS_START)) seconds"
 
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -115,13 +115,57 @@ load test_helper
 		source \"$SCRIPT_DIR/common.sh\"
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_service_logs=[\$compress_service_logs]\"
 	"
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_service_logs=[]"
 }
 
-@test "get_log_collection_args fails when REDUCE_LOGS is comma-separated" {
+@test "get_log_collection_args enables compress_service_logs when REDUCE_LOGS is compress_service_logs" {
+	run bash -c "
+		export REDUCE_LOGS='compress_service_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
+		echo \"compress_service_logs=\$compress_service_logs\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
+	assert_output --partial "compress_service_logs=1"
+}
+
+@test "get_log_collection_args accepts both REDUCE_LOGS tokens" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated_logs,compress_service_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_service_logs=\$compress_service_logs\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_service_logs=1"
+}
+
+@test "get_log_collection_args accepts both REDUCE_LOGS tokens in either order" {
+	run bash -c "
+		export REDUCE_LOGS='compress_service_logs,skip_rotated_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_service_logs=\$compress_service_logs\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_service_logs=1"
+}
+
+@test "get_log_collection_args fails when REDUCE_LOGS contains an unknown token" {
 	run bash -c "
 		export REDUCE_LOGS='skip_rotated_logs,other'
 		source \"$SCRIPT_DIR/common.sh\"
@@ -130,7 +174,7 @@ load test_helper
 
 	assert_failure
 	assert_output --partial "ERROR"
-	assert_output --partial "skip_rotated_logs,other"
+	assert_output --partial "other"
 }
 
 @test "get_log_collection_args fails when REDUCE_LOGS is unknown" {
@@ -142,7 +186,7 @@ load test_helper
 
 	assert_failure
 	assert_output --partial "ERROR"
-	assert_output --partial "skip_rotated_logs"
+	assert_output --partial "compress_service_logs"
 }
 
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -134,7 +134,7 @@ load test_helper
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
-	assert_output --partial "compress_service_logs=1"
+	assert_output --partial "compress_service_logs=true"
 }
 
 @test "get_log_collection_args accepts both REDUCE_LOGS tokens" {
@@ -148,7 +148,7 @@ load test_helper
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=[]"
-	assert_output --partial "compress_service_logs=1"
+	assert_output --partial "compress_service_logs=true"
 }
 
 @test "get_log_collection_args accepts both REDUCE_LOGS tokens in either order" {
@@ -162,7 +162,7 @@ load test_helper
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=[]"
-	assert_output --partial "compress_service_logs=1"
+	assert_output --partial "compress_service_logs=true"
 }
 
 @test "get_log_collection_args fails when REDUCE_LOGS contains an unknown token" {
@@ -186,6 +186,8 @@ load test_helper
 
 	assert_failure
 	assert_output --partial "ERROR"
+	assert_output --partial "invalid"
+	assert_output --partial "skip_rotated_logs"
 	assert_output --partial "compress_service_logs"
 }
 

--- a/tests/service_logs_util.bats
+++ b/tests/service_logs_util.bats
@@ -149,3 +149,52 @@ run_service_logs_test() {
 	assert_success
 	assert_output --partial "INFO: Collecting host service logs for testservice"
 }
+
+@test "collect_service_logs writes uncompressed .log by default" {
+	run_service_logs_test "
+		unset REDUCE_LOGS
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		collect_service_logs --role=master testservice 2>&1
+		wait \"\${PIDS[@]}\" 2>/dev/null || true
+		PIDS=()
+		[[ -f \"$TEST_TMPDIR/service_logs/masters/testservice_service.log\" ]] && echo 'uncompressed log present'
+		[[ ! -f \"$TEST_TMPDIR/service_logs/masters/testservice_service.log.gz\" ]] && echo 'gzip absent'
+	"
+
+	assert_success
+	assert_output --partial "uncompressed log present"
+	assert_output --partial "gzip absent"
+}
+
+@test "collect_service_logs writes .log.gz when REDUCE_LOGS is compress_service_logs" {
+	run_service_logs_test "
+		export REDUCE_LOGS='compress_service_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		collect_service_logs --role=master testservice 2>&1
+		wait \"\${PIDS[@]}\" 2>/dev/null || true
+		PIDS=()
+		[[ -f \"$TEST_TMPDIR/service_logs/masters/testservice_service.log.gz\" ]] && echo 'gzip log present'
+		[[ ! -f \"$TEST_TMPDIR/service_logs/masters/testservice_service.log\" ]] && echo 'uncompressed absent'
+	"
+
+	assert_success
+	assert_output --partial "gzip log present"
+	assert_output --partial "uncompressed absent"
+}
+
+@test "collect_service_logs writes .log.gz when REDUCE_LOGS includes compress_service_logs with skip_rotated_logs" {
+	run_service_logs_test "
+		export REDUCE_LOGS='skip_rotated_logs,compress_service_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		collect_service_logs --role=master testservice 2>&1
+		wait \"\${PIDS[@]}\" 2>/dev/null || true
+		PIDS=()
+		[[ -f \"$TEST_TMPDIR/service_logs/masters/testservice_service.log.gz\" ]] && echo 'gzip log present'
+	"
+
+	assert_success
+	assert_output --partial "gzip log present"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service log collection now supports optional gzip compression, producing `.log.gz` files when enabled and uncompressed `.log` files by default.
  * Windows node log collection now defaults to uncompressed logs, with optional gzip compression available.
  * Log reduction options accept comma- or space-separated values, including skipping rotated logs and enabling compression.
* **Bug Fixes**
  * Invalid log reduction options now produce clearer validation errors.
* **Tests**
  * Expanded coverage for option parsing and compressed/uncompressed output combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->