### PR TITLE
OCPBUGS-85052: feat: add pacemaker resource to mustgather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -54,6 +54,8 @@ group_resources+=(internalreleaseimages.machineconfiguration.openshift.io)
 # Networking Resources
 group_resources+=(networks.operator.openshift.io)
 
+# Two Node Fencing (Pacemaker) Resources
+group_resources+=(pacemakerclusters.etcd.openshift.io)
 
 # Assisted Installer
 named_resources+=(ns/assisted-installer)


### PR DESCRIPTION
in two node fencing deployments when the controlPlaneTopology is DualReplica a paceameker cr exists which captures the status of the pacemaker service, we should grab this information during the mustgather steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster inspection now includes Pacemaker cluster resources in gathered support data, improving visibility into Pacemaker-related objects during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->