### PR TITLE
MG-234: optional post-gather log compression via REDUCE_LOGS=compress_logs

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -34,9 +34,11 @@ get_log_collection_args() {
 	# REDUCE_LOGS: unset = defaults. Comma or space separated list of:
 	#   skip_rotated_logs     - omit --rotated-pod-logs from oc adm inspect
 	#   compress_service_logs - gzip host service / Windows node logs (see gather_service_logs_util, gather_windows_node_logs)
+	#   compress_logs         - gzip collected .log files >=10MB after gather (before rsync)
 
 	rotated_pod_logs_arg="--rotated-pod-logs"
 	compress_service_logs=""
+	compress_after_gather=""
 
 	if [ -n "${REDUCE_LOGS:-}" ]; then
 		# Normalize commas to spaces, then validate each option.
@@ -50,10 +52,13 @@ get_log_collection_args() {
 			compress_service_logs)
 				compress_service_logs=true
 				;;
+			compress_logs)
+				compress_after_gather=true
+				;;
 			"")
 				;;
 			*)
-				echo "ERROR: REDUCE_LOGS unknown value '${reduce_logs_option}'. Allowed: skip_rotated_logs, compress_service_logs (got: [${REDUCE_LOGS}])." >&2
+				echo "ERROR: REDUCE_LOGS unknown value '${reduce_logs_option}'. Allowed: skip_rotated_logs, compress_service_logs, compress_logs (got: [${REDUCE_LOGS}])." >&2
 				exit 1
 				;;
 			esac
@@ -78,6 +83,36 @@ get_log_collection_args() {
 	fi
 
 	# Export globals used by gather_* scripts that source this file (also satisfies ShellCheck SC2034):
-	# log_collection_args, node_log_collection_args, rotated_pod_logs_arg, compress_service_logs.
-	export log_collection_args node_log_collection_args rotated_pod_logs_arg compress_service_logs
+	# log_collection_args, node_log_collection_args, rotated_pod_logs_arg, compress_service_logs, compress_after_gather.
+	export log_collection_args node_log_collection_args rotated_pod_logs_arg compress_service_logs compress_after_gather
+}
+
+# Compress collected .log / .log.* files larger than 10MB (skip already-gzipped).
+# Uses gzip -1 (fastest). Parallelism defaults to 4; override with COMPRESS_LOGS_JOBS.
+compress_logs() {
+	local target_dir="${1:-/must-gather}"
+	local max_jobs="${COMPRESS_LOGS_JOBS:-4}"
+	local -a pids=()
+	local log_file
+	local pid
+
+	if [ ! -d "${target_dir}" ]; then
+		echo "WARNING: compress_logs: target directory ${target_dir} does not exist, skipping." >&2
+		return 0
+	fi
+
+	echo "Compressing collected logs in parallel (jobs=${max_jobs})..."
+	while IFS= read -r -d '' log_file; do
+		while [ "${#pids[@]}" -ge "${max_jobs}" ]; do
+			wait "${pids[0]}" || true
+			pids=("${pids[@]:1}")
+		done
+		gzip -1 "${log_file}" &
+		pids+=($!)
+	done < <(find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M -print0)
+
+	for pid in "${pids[@]}"; do
+		wait "${pid}" || true
+	done
+	echo "Compression complete."
 }

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -204,5 +204,11 @@ fi
 # Gather ARO information
 /usr/bin/gather_aro
 
+# Optionally compress collected log files before the sidecar copies them out.
+# Enabled via REDUCE_LOGS=compress_logs.
+if [ "${compress_after_gather}" = "true" ]; then
+	compress_logs
+fi
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -116,11 +116,13 @@ load test_helper
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
 		echo \"compress_service_logs=[\$compress_service_logs]\"
+		echo \"compress_after_gather=[\$compress_after_gather]\"
 	"
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=[]"
 	assert_output --partial "compress_service_logs=[]"
+	assert_output --partial "compress_after_gather=[]"
 }
 
 @test "get_log_collection_args enables compress_service_logs when REDUCE_LOGS is compress_service_logs" {
@@ -130,11 +132,27 @@ load test_helper
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
 		echo \"compress_service_logs=\$compress_service_logs\"
+		echo \"compress_after_gather=[\$compress_after_gather]\"
 	"
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
 	assert_output --partial "compress_service_logs=true"
+	assert_output --partial "compress_after_gather=[]"
+}
+
+@test "get_log_collection_args enables compress_after_gather when REDUCE_LOGS is compress_logs" {
+	run bash -c "
+		export REDUCE_LOGS='compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
+	assert_output --partial "compress_after_gather=true"
 }
 
 @test "get_log_collection_args accepts both REDUCE_LOGS tokens" {
@@ -165,6 +183,36 @@ load test_helper
 	assert_output --partial "compress_service_logs=true"
 }
 
+@test "get_log_collection_args accepts compress_logs with skip_rotated_logs" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated_logs,compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_after_gather=true"
+}
+
+@test "get_log_collection_args accepts all REDUCE_LOGS tokens together" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated_logs,compress_service_logs,compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_service_logs=\$compress_service_logs\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_service_logs=true"
+	assert_output --partial "compress_after_gather=true"
+}
+
 @test "get_log_collection_args fails when REDUCE_LOGS contains an unknown token" {
 	run bash -c "
 		export REDUCE_LOGS='skip_rotated_logs,other'
@@ -189,6 +237,31 @@ load test_helper
 	assert_output --partial "invalid"
 	assert_output --partial "skip_rotated_logs"
 	assert_output --partial "compress_service_logs"
+	assert_output --partial "compress_logs"
+}
+
+@test "compress_logs gzips large .log files and leaves small ones alone" {
+	run bash -c "
+		source \"$SCRIPT_DIR/common.sh\"
+		mkdir -p \"$TEST_TMPDIR/logs/nested\"
+		# 11MB file should be compressed (>10M threshold)
+		dd if=/dev/zero of=\"$TEST_TMPDIR/logs/large.log\" bs=1024 count=11264 status=none
+		# small file should remain uncompressed
+		echo 'small' > \"$TEST_TMPDIR/logs/nested/small.log\"
+		# already-gzipped should be skipped
+		echo 'already' | gzip > \"$TEST_TMPDIR/logs/already.log.gz\"
+		compress_logs \"$TEST_TMPDIR/logs\"
+		[[ -f \"$TEST_TMPDIR/logs/large.log.gz\" ]] && echo 'large compressed'
+		[[ ! -f \"$TEST_TMPDIR/logs/large.log\" ]] && echo 'large original removed'
+		[[ -f \"$TEST_TMPDIR/logs/nested/small.log\" ]] && echo 'small kept'
+		[[ -f \"$TEST_TMPDIR/logs/already.log.gz\" ]] && echo 'preexisting gz kept'
+	"
+
+	assert_success
+	assert_output --partial "large compressed"
+	assert_output --partial "large original removed"
+	assert_output --partial "small kept"
+	assert_output --partial "preexisting gz kept"
 }
 
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {


### PR DESCRIPTION
## Summary
- Adds `REDUCE_LOGS=compress_logs` to gzip collected `.log` / `.log.*` files larger than 10MB after all gatherers finish and before the sidecar rsyncs data out.
- Parallelism defaults to 4 jobs; override with `COMPRESS_LOGS_JOBS`.
- Composable with existing `skip_rotated_logs` and `compress_service_logs`.
- When `REDUCE_LOGS` is unset, behavior is unchanged.

### Usage
```bash
oc adm must-gather --image=<image> -- env REDUCE_LOGS=compress_logs /usr/bin/gather

# tune parallelism
oc adm must-gather --image=<image> -- env REDUCE_LOGS=compress_logs COMPRESS_LOGS_JOBS=4 /usr/bin/gather

# combine options
oc adm must-gather --image=<image> -- env REDUCE_LOGS=compress_logs,skip_rotated_logs /usr/bin/gather
```

## Benchmark (Justin’s cluster)

Full `oc adm must-gather` / `/usr/bin/gather`, no `--since`, `--timeout=4h`, `--volume-percentage=90`.

Cluster: OCP `4.21.0-0.nightly-multi-2026-02-28-140032-1`.

| Scenario | Image | `REDUCE_LOGS` | `COMPRESS_LOGS_JOBS` | Duration | On-disk size | Files | Exit |
|---|---|---|---|---|---|---|---|
| Baseline (no compression) | stock `openshift/must-gather:latest` | unset | — | **2h 54m 19s** (10459s) | **32.12 GiB** | 6622 (984 `.gz`) | 0 |
| `compress_logs` only | `mg-234-bench/must-gather:latest` | `compress_logs` | 4 | *in progress / pending* | *pending* | *pending* | — |

**Baseline command:**
```bash
oc adm must-gather \
  --timeout=4h \
  --volume-percentage=90 \
  --image=image-registry.openshift-image-registry.svc:5000/openshift/must-gather:latest \
  --dest-dir=<out>/01-baseline \
  -- env /usr/bin/gather
```

**Compressed command (jobs=4):**
```bash
oc adm must-gather \
  --timeout=4h \
  --volume-percentage=90 \
  --image=<mg-234 image> \
  --dest-dir=<out>/03-compress_logs-jobs4 \
  -- env REDUCE_LOGS=compress_logs COMPRESS_LOGS_JOBS=4 /usr/bin/gather
```

> Size/time delta and reduction % will be updated in this PR description when the `compress_logs` (jobs=4) run completes. A jobs=2 run is currently in progress on the same cluster as part of the matrix.

## Test plan
- [x] Unit tests for `REDUCE_LOGS=compress_logs` parsing and `compress_logs()` behavior (`tests/common.bats`)
- [x] Baseline full must-gather on real cluster (time + size recorded above)
- [ ] Full must-gather with `REDUCE_LOGS=compress_logs COMPRESS_LOGS_JOBS=4`; update comparison table
- [ ] Optional: jobs=2 vs jobs=4 vs jobs=8 wall-clock comparison
- [ ] Optional: combos with `compress_service_logs` / `skip_rotated_logs`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional post-collection compression for log files.
  - Large log files are compressed automatically, while small or already-compressed files remain unchanged.
  - Compression can run in parallel with a configurable number of jobs.
  - Missing directories and individual compression failures are handled without stopping collection.

- **Tests**
  - Added coverage for compression settings, supported options, file-size handling, and existing compressed logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->