### PR TITLE
MG-234: REDUCE_LOGS=compress_logs compresses large must-gather logs before rsync

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -92,27 +92,9 @@ get_log_collection_args() {
 compress_logs() {
 	local target_dir="${1:-/must-gather}"
 	local max_jobs="${COMPRESS_LOGS_JOBS:-4}"
-	local -a pids=()
-	local log_file
-	local pid
-
-	if [ ! -d "${target_dir}" ]; then
-		echo "WARNING: compress_logs: target directory ${target_dir} does not exist, skipping." >&2
-		return 0
-	fi
 
 	echo "Compressing collected logs in parallel (jobs=${max_jobs})..."
-	while IFS= read -r -d '' log_file; do
-		while [ "${#pids[@]}" -ge "${max_jobs}" ]; do
-			wait "${pids[0]}" || true
-			pids=("${pids[@]:1}")
-		done
-		gzip -1 "${log_file}" &
-		pids+=($!)
-	done < <(find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M -print0)
-
-	for pid in "${pids[@]}"; do
-		wait "${pid}" || true
-	done
+	find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M \
+		| xargs -P "${max_jobs}" gzip -1
 	echo "Compression complete."
 }

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -34,9 +34,11 @@ get_log_collection_args() {
 	# REDUCE_LOGS: unset = defaults. Comma or space separated list of:
 	#   skip_rotated_logs     - omit --rotated-pod-logs from oc adm inspect
 	#   compress_service_logs - gzip host service / Windows node logs (see gather_service_logs_util, gather_windows_node_logs)
+	#   compress_logs         - gzip collected .log files >=10MB after gather (before rsync)
 
 	rotated_pod_logs_arg="--rotated-pod-logs"
 	compress_service_logs=""
+	compress_after_gather=""
 
 	if [ -n "${REDUCE_LOGS:-}" ]; then
 		# Normalize commas to spaces, then validate each option.
@@ -50,10 +52,13 @@ get_log_collection_args() {
 			compress_service_logs)
 				compress_service_logs=true
 				;;
+			compress_logs)
+				compress_after_gather=true
+				;;
 			"")
 				;;
 			*)
-				echo "ERROR: REDUCE_LOGS unknown value '${reduce_logs_option}'. Allowed: skip_rotated_logs, compress_service_logs (got: [${REDUCE_LOGS}])." >&2
+				echo "ERROR: REDUCE_LOGS unknown value '${reduce_logs_option}'. Allowed: skip_rotated_logs, compress_service_logs, compress_logs (got: [${REDUCE_LOGS}])." >&2
 				exit 1
 				;;
 			esac
@@ -78,6 +83,36 @@ get_log_collection_args() {
 	fi
 
 	# Export globals used by gather_* scripts that source this file (also satisfies ShellCheck SC2034):
-	# log_collection_args, node_log_collection_args, rotated_pod_logs_arg, compress_service_logs.
-	export log_collection_args node_log_collection_args rotated_pod_logs_arg compress_service_logs
+	# log_collection_args, node_log_collection_args, rotated_pod_logs_arg, compress_service_logs, compress_after_gather.
+	export log_collection_args node_log_collection_args rotated_pod_logs_arg compress_service_logs compress_after_gather
+}
+
+# Compress collected .log / .log.* files larger than 10MB (skip already-gzipped).
+# Uses gzip -1 (fastest). Parallelism defaults to 4; override with COMPRESS_LOGS_JOBS.
+compress_logs() {
+	local target_dir="${1:-/must-gather}"
+	local max_jobs="${COMPRESS_LOGS_JOBS:-4}"
+	local -a pids=()
+	local log_file
+	local pid
+
+	if [ ! -d "${target_dir}" ]; then
+		echo "WARNING: compress_logs: target directory ${target_dir} does not exist, skipping." >&2
+		return 0
+	fi
+
+	echo "Compressing collected logs in parallel (jobs=${max_jobs})..."
+	while IFS= read -r -d '' log_file; do
+		while [ "${#pids[@]}" -ge "${max_jobs}" ]; do
+			wait "${pids[0]}" || true
+			pids=("${pids[@]:1}")
+		done
+		gzip -1 "${log_file}" &
+		pids+=($!)
+	done < <(find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M -print0)
+
+	for pid in "${pids[@]}"; do
+		wait "${pid}" || true
+	done
+	echo "Compression complete."
 }

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -88,13 +88,14 @@ get_log_collection_args() {
 }
 
 # Compress collected .log / .log.* files larger than 10MB (skip already-gzipped).
-# Uses gzip -1 (fastest). Parallelism defaults to 4; override with COMPRESS_LOGS_JOBS.
+# Uses gzip -1 (fastest) with 2 parallel jobs.
 compress_logs() {
 	local target_dir="${1:-/must-gather}"
-	local max_jobs="${COMPRESS_LOGS_JOBS:-4}"
 
-	echo "Compressing collected logs in parallel (jobs=${max_jobs})..."
-	find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M \
-		| xargs -P "${max_jobs}" gzip -1
+	echo "Compressing collected logs in parallel (jobs=2)..."
+	# -print0 / xargs -0: keep path names with spaces/quotes intact
+	# -r: do not run gzip when find matches nothing (GNU xargs)
+	find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M -print0 \
+		| xargs -0 -r -P 2 gzip -1
 	echo "Compression complete."
 }

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -93,9 +93,14 @@ compress_logs() {
 	local target_dir="${1:-/must-gather}"
 
 	echo "Compressing collected logs in parallel (jobs=2)..."
-	# -print0 / xargs -0: keep path names with spaces/quotes intact
-	# -r: do not run gzip when find matches nothing (GNU xargs)
-	find "${target_dir}" \( -name '*.log' -o -name '*.log.*' \) ! -name '*.gz' -size +10M -print0 \
-		| xargs -0 -r -P 2 gzip -1
+	# Find large logs, then gzip up to 2 at a time.
+	# -print0 / xargs -0: safe with spaces in paths
+	# xargs -r: skip gzip if find matches nothing
+	find "${target_dir}" \
+		\( -name '*.log' -o -name '*.log.*' \) \
+		! -name '*.gz' \
+		-size +10M \
+		-print0 |
+		xargs -0 -r -P 2 gzip -1
 	echo "Compression complete."
 }

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -204,5 +204,11 @@ fi
 # Gather ARO information
 /usr/bin/gather_aro
 
+# Optionally compress collected log files before the sidecar copies them out.
+# Enabled via REDUCE_LOGS=compress_logs.
+if [ "${compress_after_gather}" = "true" ]; then
+	compress_logs
+fi
+
 # force disk flush to ensure that all data gathered is accessible in the copy container
 sync

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -264,6 +264,37 @@ load test_helper
 	assert_output --partial "preexisting gz kept"
 }
 
+@test "compress_logs gzips large .log files whose names contain spaces" {
+	run bash -c "
+		source \"$SCRIPT_DIR/common.sh\"
+		mkdir -p \"$TEST_TMPDIR/logs\"
+		dd if=/dev/zero of=\"$TEST_TMPDIR/logs/file with spaces.log\" bs=1024 count=11264 status=none
+		compress_logs \"$TEST_TMPDIR/logs\"
+		[[ -f \"$TEST_TMPDIR/logs/file with spaces.log.gz\" ]] && echo 'spaced compressed'
+		[[ ! -f \"$TEST_TMPDIR/logs/file with spaces.log\" ]] && echo 'spaced original removed'
+	"
+
+	assert_success
+	assert_output --partial "spaced compressed"
+	assert_output --partial "spaced original removed"
+}
+
+@test "compress_logs skips gzip when no files match" {
+	run bash -c "
+		source \"$SCRIPT_DIR/common.sh\"
+		mkdir -p \"$TEST_TMPDIR/empty-logs\"
+		echo 'tiny' > \"$TEST_TMPDIR/empty-logs/small.log\"
+		compress_logs \"$TEST_TMPDIR/empty-logs\"
+		[[ -f \"$TEST_TMPDIR/empty-logs/small.log\" ]] && echo 'small kept'
+	"
+
+	assert_success
+	assert_output --partial "Compressing collected logs"
+	assert_output --partial "Compression complete"
+	assert_output --partial "small kept"
+	refute_output --partial "gzip:"
+}
+
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {
 	run bash -c "
 		export MUST_GATHER_SINCE='8h'

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -116,11 +116,13 @@ load test_helper
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
 		echo \"compress_service_logs=[\$compress_service_logs]\"
+		echo \"compress_after_gather=[\$compress_after_gather]\"
 	"
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=[]"
 	assert_output --partial "compress_service_logs=[]"
+	assert_output --partial "compress_after_gather=[]"
 }
 
 @test "get_log_collection_args enables compress_service_logs when REDUCE_LOGS is compress_service_logs" {
@@ -130,11 +132,27 @@ load test_helper
 		get_log_collection_args
 		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
 		echo \"compress_service_logs=\$compress_service_logs\"
+		echo \"compress_after_gather=[\$compress_after_gather]\"
 	"
 
 	assert_success
 	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
 	assert_output --partial "compress_service_logs=true"
+	assert_output --partial "compress_after_gather=[]"
+}
+
+@test "get_log_collection_args enables compress_after_gather when REDUCE_LOGS is compress_logs" {
+	run bash -c "
+		export REDUCE_LOGS='compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=\$rotated_pod_logs_arg\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=--rotated-pod-logs"
+	assert_output --partial "compress_after_gather=true"
 }
 
 @test "get_log_collection_args accepts both REDUCE_LOGS tokens" {
@@ -165,6 +183,36 @@ load test_helper
 	assert_output --partial "compress_service_logs=true"
 }
 
+@test "get_log_collection_args accepts compress_logs with skip_rotated_logs" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated_logs,compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_after_gather=true"
+}
+
+@test "get_log_collection_args accepts all REDUCE_LOGS tokens together" {
+	run bash -c "
+		export REDUCE_LOGS='skip_rotated_logs,compress_service_logs,compress_logs'
+		source \"$SCRIPT_DIR/common.sh\"
+		get_log_collection_args
+		echo \"rotated_pod_logs_arg=[\$rotated_pod_logs_arg]\"
+		echo \"compress_service_logs=\$compress_service_logs\"
+		echo \"compress_after_gather=\$compress_after_gather\"
+	"
+
+	assert_success
+	assert_output --partial "rotated_pod_logs_arg=[]"
+	assert_output --partial "compress_service_logs=true"
+	assert_output --partial "compress_after_gather=true"
+}
+
 @test "get_log_collection_args fails when REDUCE_LOGS contains an unknown token" {
 	run bash -c "
 		export REDUCE_LOGS='skip_rotated_logs,other'
@@ -189,6 +237,31 @@ load test_helper
 	assert_output --partial "invalid"
 	assert_output --partial "skip_rotated_logs"
 	assert_output --partial "compress_service_logs"
+	assert_output --partial "compress_logs"
+}
+
+@test "compress_logs gzips large .log files and leaves small ones alone" {
+	run bash -c "
+		source \"$SCRIPT_DIR/common.sh\"
+		mkdir -p \"$TEST_TMPDIR/logs/nested\"
+		# 11MB file should be compressed (>10M threshold)
+		dd if=/dev/zero of=\"$TEST_TMPDIR/logs/large.log\" bs=1024 count=11264 status=none
+		# small file should remain uncompressed
+		echo 'small' > \"$TEST_TMPDIR/logs/nested/small.log\"
+		# already-gzipped should be skipped
+		echo 'already' | gzip > \"$TEST_TMPDIR/logs/already.log.gz\"
+		compress_logs \"$TEST_TMPDIR/logs\"
+		[[ -f \"$TEST_TMPDIR/logs/large.log.gz\" ]] && echo 'large compressed'
+		[[ ! -f \"$TEST_TMPDIR/logs/large.log\" ]] && echo 'large original removed'
+		[[ -f \"$TEST_TMPDIR/logs/nested/small.log\" ]] && echo 'small kept'
+		[[ -f \"$TEST_TMPDIR/logs/already.log.gz\" ]] && echo 'preexisting gz kept'
+	"
+
+	assert_success
+	assert_output --partial "large compressed"
+	assert_output --partial "large original removed"
+	assert_output --partial "small kept"
+	assert_output --partial "preexisting gz kept"
 }
 
 @test "get_log_collection_args formats node_log_collection_args from MUST_GATHER_SINCE" {


### PR DESCRIPTION
## Summary
- Add `REDUCE_LOGS=compress_logs` to gzip collected `.log` / `.log.*` files larger than 10MB after gather finishes and before `oc` rsyncs `/must-gather`.
- Parallelism defaults to 4 and can be tuned with `COMPRESS_LOGS_JOBS`.
- Unset / other `REDUCE_LOGS` values keep existing behavior; `compress_logs` combines with `skip_rotated_logs` and `compress_service_logs`.

## Usage
```bash
oc adm must-gather -- REDUCE_LOGS=compress_logs /usr/bin/gather
oc adm must-gather -- REDUCE_LOGS=compress_logs COMPRESS_LOGS_JOBS=8 /usr/bin/gather
```

## Test plan
- [x] `./tmp/bin/bats tests/common.bats`
- [x] Full gather without `REDUCE_LOGS` unchanged
- [x] `REDUCE_LOGS=compress_logs`: large logs become `.gz`, small logs untouched
- [x] Combined tokens (`skip_rotated_logs,compress_service_logs,compress_logs`) work
- [x] Invalid `REDUCE_LOGS` value still errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional post-collection compression for large log files.
  * Supports parallel gzip compression of `.log` and `.log.*` files larger than 10 MB.
  * Preserves small logs and skips files that are already compressed.
* **Bug Fixes**
  * Improved validation and handling of log-reduction settings.
* **Tests**
  * Added coverage for compression settings, token combinations, filenames with spaces, and file-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->