### PR TITLE
WINC-2092: Add windows_exporter log collection

### DIFF
--- a/collection-scripts/gather_windows_node_logs
+++ b/collection-scripts/gather_windows_node_logs
@@ -14,6 +14,7 @@ LOGS+=(kubelet/kubelet.log)
 LOGS+=(containerd/containerd.log)
 LOGS+=(wicd/windows-instance-config-daemon.exe.INFO wicd/windows-instance-config-daemon.exe.ERROR wicd/windows-instance-config-daemon.exe.WARNING)
 LOGS+=(csi-proxy/csi-proxy.log)
+LOGS+=(windows_exporter/windows_exporter.log)
 
 # if the cluster has no Windows nodes skip this script
 WIN_NODES=$(/usr/bin/oc get no -l kubernetes.io/os=windows)


### PR DESCRIPTION
Add windows_exporter/windows_exporter.log to the LOGS array in gather_windows_node_logs to collect windows_exporter service logs from Windows nodes.

follow-up to
- https://github.com/openshift/windows-machine-config-operator/pull/4355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows Exporter logs to the Windows node log collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->